### PR TITLE
Fix recover from overvoltage/undervoltage state in bms_bq769x0.c

### DIFF
--- a/src/bq769x0/bms_bq769x0.c
+++ b/src/bq769x0/bms_bq769x0.c
@@ -507,10 +507,7 @@ void bms_update_error_flags(BmsConfig *conf, BmsStatus *status)
     {
         error_flags_temp |= 1U << BMS_ERR_DIS_UNDERTEMP;
     }
-<<<<<<< HEAD
 
-=======
->>>>>>> 2ad31e621244d5f6d5caac1192dfde203b9eaf4e
     status -> error_flags = error_flags_temp;
 }
 

--- a/src/bq769x0/bms_bq769x0.c
+++ b/src/bq769x0/bms_bq769x0.c
@@ -508,7 +508,7 @@ void bms_update_error_flags(BmsConfig *conf, BmsStatus *status)
         error_flags_temp |= 1U << BMS_ERR_DIS_UNDERTEMP;
     }
 
-    status -> error_flags = error_flags_temp;
+    status->error_flags = error_flags_temp;
 }
 
 void bms_handle_errors(BmsConfig *conf, BmsStatus *status)


### PR DESCRIPTION
BMS with BQ76930 did not recover from state "overvoltage" or "undervoltage". BMS needs a reset to enable CHG/DSG MOSFETs again. 
- MOSFET "switch on" depends on ov_reset and uv_reset levels (improved bouncing behaviour)
- if first clear of error flag in SYS_STATS fails, it is retried again until flag clears (not dependent on ALERT-line interrupt)