### PR TITLE
bq769x0: Fix address and CRC detection

### DIFF
--- a/app/src/bq769x0/interface.c
+++ b/app/src/bq769x0/interface.c
@@ -162,7 +162,7 @@ int bq769x0_init()
     alert_interrupt_flag = true; // init with true to check and clear errors at start-up
 
     int err = determine_address_and_crc();
-    if (err) {
+    if (!err) {
         // initial settings for bq769x0
         bq769x0_write_byte(BQ769X0_SYS_CTRL1, 0b00011000); // switch external thermistor and ADC on
         bq769x0_write_byte(BQ769X0_SYS_CTRL2, 0b01000000); // switch CC_EN on


### PR DESCRIPTION
Hi,
I am in the process of porting bms-firmware for some noname BMS I found with bq76940 and stm32f103.
In the process I encountered problems with detection of the BMS IC, I was getting an error:
`BMS communication error`
but after veryfing with logic analyzer, the communication turned out to be correct.
The bug was caused by an erroneous (oposite) interpretation of return values of `determine_address_and_crc` function.
I suspect this bug might affect other boards already supported by bms-firmware, but I have no way of verifying that/