### PR TITLE
boards: BMS C1: fix version 0.3 in overlay

### DIFF
--- a/boards/riscv/bms_c1/bms_c1_0_3_0.overlay
+++ b/boards/riscv/bms_c1/bms_c1_0_3_0.overlay
@@ -6,8 +6,8 @@
 
 / {
 	pcb {
-		version-str = "v0.4";
-		version-num = <4>;
+		version-str = "v0.3";
+		version-num = <3>;
 	};
 };
 


### PR DESCRIPTION
Upon reviewing and testing https://github.com/LibreSolar/bms-firmware/pull/37 I noticed an issue with the firmware version display. Specifically, the version information for the C1 0.3 BMS is not being printed correctly.