### PR TITLE
BMS app: Call SOC update function regularly

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -63,6 +63,8 @@ int main(void)
             LOG_ERR("Failed to read data from BMS IC: %d", err);
         }
 
+        bms_soc_update(&bms);
+
         bms_state_machine(&bms);
 
         if (button_pressed_for_3s()) {


### PR DESCRIPTION
Fixes #40

I'm working on some improvements to the test framework, which will also include the SOC calculation. But that's not quite ready, yet. So let's first fix this bug.