### PR TITLE
docs: Fix missing file references: helper.h and bms.h

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2,7 +2,8 @@
 #
 # Only contains most important options, as HTML rendering is done by Sphinx
 
-INPUT              = ../app/src
+INPUT              = ../
+EXCLUDE_PATTERNS   = */build*
 OUTPUT_DIRECTORY   = build/doxygen
 RECURSIVE          = YES
 GENERATE_HTML      = NO

--- a/docs/src/api/bms.rst
+++ b/docs/src/api/bms.rst
@@ -1,5 +1,5 @@
 BMS
 ===
 
-.. doxygenfile:: bms.h
+.. doxygenfile:: include/bms/bms.h
    :project: app

--- a/docs/src/api/misc.rst
+++ b/docs/src/api/misc.rst
@@ -10,5 +10,5 @@ Button
 Helper
 ------
 
-.. doxygenfile:: helper.h
+.. doxygenfile:: include/helper.h
    :project: app


### PR DESCRIPTION
I've noticed missing file references in the documentation:
- `doxygenfile: Cannot find file “helper.h”`
- `doxygenfile: Cannot find file “bms.h”`

I'm considering a fix but am unsure if it's in line with the current plans, or if it's better to wait for the Zephyr driver documentation. The fix would be:
1. Correcting the paths for `helper.h` and `bms.h`.
2. Updating the Doxygen setup to recognize these files.
