### PR TITLE
ISL94202 driver init and Kconfig fixes

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -42,18 +42,6 @@ config CELL_TYPE
     default 3 if CELL_TYPE_NMC_HV
     default 4 if CELL_TYPE_LTO
 
-config NUM_CELLS_IN_SERIES
-    int "Number of cells for single battery"
-    default 3 if CELL_TYPE_NMC || CELL_TYPE_NMC_HV
-    default 4 if CELL_TYPE_LFP
-    default 5 if CELL_TYPE_LTO
-    range 3 16
-    help
-      Typical choices:
-      - 3 for 12V NMC Li-Ion battery
-      - 4 for 12V LiFePO4 battery
-      - 5 for 12V Titanate battery
-
 endmenu
 
 # include main Zephyr menu entries from Zephyr root directory

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -34,6 +34,3 @@ CONFIG_THINGSET_NODE_NAME="Libre Solar BMS"
 
 # Select cell type for initial configuration: LFP (default), NMC, NMC_HV or LTO
 #CONFIG_CELL_TYPE_???=y
-
-# Manually define number of cells connected in series (only necessary for boards with ISL94202)
-#CONFIG_NUM_CELLS_IN_SERIES=?

--- a/docs/src/dev/customization.rst
+++ b/docs/src/dev/customization.rst
@@ -38,8 +38,8 @@ By default, the BMS is configured for LiFePO4 cells (``CONFIG_CELL_TYPE_LFP``).
 Possible other pre-defined options are ``CONFIG_BAT_TYPE_NMC``, ``CONFIG_BAT_TYPE_NMC_HV`` and
 ``CONFIG_BAT_TYPE_LTO``.
 
-The number of cells only has to be specified via ``CONFIG_NUM_CELLS_IN_SERIES`` for boards with the
-ISL94202 chip. For all other chips it is detected automatically and the setting is ignored.
+The number of cells only has to be specified via ``CONFIG_BMS_IC_ISL94202_NUM_CELLS`` for boards
+with the ISL94202 chip. For all other chips it is detected automatically.
 
 To compile the firmware with default settings e.g. for a 24V LiFePO4 battery with a nominal capacity
 of 100Ah, add the following to ``prj.conf`` or the board-specific ``.conf`` file:
@@ -48,7 +48,6 @@ of 100Ah, add the following to ``prj.conf`` or the board-specific ``.conf`` file
 
     CONFIG_BAT_CAPACITY_AH=100
     CONFIG_CELL_TYPE_LFP=y
-    CONFIG_NUM_CELLS_IN_SERIES=8
 
 Configure serial interface
 """"""""""""""""""""""""""

--- a/drivers/bms_ic/Kconfig
+++ b/drivers/bms_ic/Kconfig
@@ -51,6 +51,19 @@ config BMS_IC_ISL94202
 	help
 	  Driver for Intersil/Renesas ISL94202.
 
+config BMS_IC_ISL94202_NUM_CELLS
+    int "Exact number of cells in series"
+    range 3 8
+    default 8
+    help
+      The exact number of cells used by the application is needed for configuration of the chip.
+
+      Typical choices:
+      - 3 for 12V NMC Li-Ion battery
+      - 4 for 12V LiFePO4 battery
+      - 5 for 12V Titanate battery
+      - 8 for 24V LiFePO4 battery
+
 config BMS_IC_CURRENT_MONITORING
 	bool "Use BMS IC current monitoring"
 	depends on BMS_IC_HAS_CURRENT_MONITORING

--- a/drivers/bms_ic/isl94202/isl94202.c
+++ b/drivers/bms_ic/isl94202/isl94202.c
@@ -625,7 +625,7 @@ static int isl94202_init(const struct device *dev)
     /* activate pull-up at I2C SDA and SCL */
     gpio_pin_configure_dt(&dev_config->i2c_pullup, GPIO_OUTPUT_ACTIVE);
 
-    err = set_num_cells(dev, CONFIG_NUM_CELLS_IN_SERIES);
+    err = set_num_cells(dev, CONFIG_BMS_IC_ISL94202_NUM_CELLS);
     if (err) {
         return err;
     }

--- a/tests/prj.conf
+++ b/tests/prj.conf
@@ -22,8 +22,5 @@ CONFIG_BAT_CAPACITY_AH=100
 # Select cell type for initial configuration: LFP (default), NMC, NMC_HV or LTO
 CONFIG_CELL_TYPE_LFP=y
 
-# Change number of cells connected in series (matching 12V battery by default if not set)
-CONFIG_NUM_CELLS_IN_SERIES=8
-
 CONFIG_BMS_IC=y
 CONFIG_BMS_IC_MAX_THERMISTORS=2

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -41,6 +41,8 @@ void setup()
 {
     bms_ic_assign_data(bms_ic, &bms.ic_data);
 
+    bms_ic_set_mode(bms_ic, BMS_IC_MODE_ACTIVE);
+
     bms.ic_conf.dis_sc_limit = 35.0;
     bms.ic_conf.dis_sc_delay_us = 200;
 


### PR DESCRIPTION
This PR contains some fixes to the ISL94202 driver, Kconfig and tests. See commit messages for details.

The fixes are partly needed for a restructuring of the unit tests I am currently working on.

@pasrom this does not really affect the bq769x2 driver, just adding you as a reviewer FYI.