### PR TITLE
Make OCV & SoC points configurable via ThingSet

### DIFF
--- a/app/Kconfig
+++ b/app/Kconfig
@@ -31,6 +31,9 @@ choice
 
     config CELL_TYPE_LTO
         bool "NMC/Titanate, 2.4 V nominal"
+
+    config CELL_TYPE_CUSTOM
+        bool "Enable manual configuration for all customizable parameters"
 endchoice
 
 # values must match enum CellType in bms.h

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -32,5 +32,5 @@ CONFIG_THINGSET_NODE_NAME="Libre Solar BMS"
 # Change default battery nominal capacity (in Ah)
 #CONFIG_BAT_CAPACITY_AH=?
 
-# Select cell type for initial configuration: LFP (default), NMC, NMC_HV or LTO
+# Select cell type for initial configuration: LFP (default), NMC, NMC_HV, LTO or CUSTOM
 #CONFIG_CELL_TYPE_???=y

--- a/app/src/bms_common.c
+++ b/app/src/bms_common.c
@@ -23,6 +23,10 @@ static float ocv_nmc[OCV_POINTS] = { 4.198F, 4.135F, 4.089F, 4.056F, 4.026F, 3.9
                                      3.924F, 3.883F, 3.858F, 3.838F, 3.819F, 3.803F, 3.787F,
                                      3.764F, 3.745F, 3.726F, 3.702F, 3.684F, 3.588F, 2.800F };
 
+static float soc_pct[OCV_POINTS] = { 100.0F, 95.0F, 90.0F, 85.0F, 80.0F, 85.0F, 70.0F,
+                                     65.0F,  60.0F, 55.0F, 50.0F, 45.0F, 40.0F, 35.0F,
+                                     30.0F,  25.0F, 20.0F, 15.0F, 10.0F, 5.0F,  0.0F };
+
 void bms_init_config(struct bms_context *bms, enum bms_cell_type type, float nominal_capacity_Ah)
 {
     bms->nominal_capacity_Ah = nominal_capacity_Ah;
@@ -69,6 +73,7 @@ void bms_init_config(struct bms_context *bms, enum bms_cell_type type, float nom
              */
             bms->ic_conf.cell_uv_limit = 2.50F;
             bms->ocv_points = ocv_lfp;
+            bms->soc_points = soc_pct;
             break;
         case CELL_TYPE_NMC:
             bms->ic_conf.cell_ov_limit = 4.25F;
@@ -79,6 +84,7 @@ void bms_init_config(struct bms_context *bms, enum bms_cell_type type, float nom
             bms->ic_conf.cell_dis_voltage_limit = 3.20F;
             bms->ic_conf.cell_uv_limit = 3.00F;
             bms->ocv_points = ocv_nmc;
+            bms->soc_points = soc_pct;
             break;
         case CELL_TYPE_LTO:
             bms->ic_conf.cell_ov_limit = 2.85F;
@@ -90,6 +96,7 @@ void bms_init_config(struct bms_context *bms, enum bms_cell_type type, float nom
             bms->ic_conf.cell_uv_limit = 1.90F;
             // ToDo: Use typical OCV curve for LTO cells
             bms->ocv_points = NULL;
+            bms->soc_points = NULL;
             break;
         case CELL_TYPE_CUSTOM:
             break;

--- a/app/src/bms_common.c
+++ b/app/src/bms_common.c
@@ -23,9 +23,13 @@ static float ocv_nmc[OCV_POINTS] = { 4.198F, 4.135F, 4.089F, 4.056F, 4.026F, 3.9
                                      3.924F, 3.883F, 3.858F, 3.838F, 3.819F, 3.803F, 3.787F,
                                      3.764F, 3.745F, 3.726F, 3.702F, 3.684F, 3.588F, 2.800F };
 
+float ocv_custom[OCV_POINTS] = { 0 };
+
 static float soc_pct[OCV_POINTS] = { 100.0F, 95.0F, 90.0F, 85.0F, 80.0F, 85.0F, 70.0F,
                                      65.0F,  60.0F, 55.0F, 50.0F, 45.0F, 40.0F, 35.0F,
                                      30.0F,  25.0F, 20.0F, 15.0F, 10.0F, 5.0F,  0.0F };
+
+float soc_custom[OCV_POINTS] = { 0 };
 
 void bms_init_config(struct bms_context *bms, enum bms_cell_type type, float nominal_capacity_Ah)
 {
@@ -99,6 +103,8 @@ void bms_init_config(struct bms_context *bms, enum bms_cell_type type, float nom
             bms->soc_points = NULL;
             break;
         case CELL_TYPE_CUSTOM:
+            bms->ocv_points = ocv_custom;
+            bms->soc_points = soc_custom;
             break;
     }
 

--- a/app/src/bms_soc.c
+++ b/app/src/bms_soc.c
@@ -13,8 +13,8 @@ void bms_soc_reset(struct bms_context *bms, int percent)
     if (percent <= 100 && percent >= 0) {
         bms->soc = percent;
     }
-    else if (bms->ocv_points != NULL) {
-        bms->soc = interpolate(bms->ocv_points, soc_pct, ARRAY_SIZE(soc_pct),
+    else if (bms->ocv_points != NULL && bms->soc_points != NULL) {
+        bms->soc = interpolate(bms->ocv_points, bms->soc_points, OCV_POINTS,
                                bms->ic_data.cell_voltage_avg);
     }
     else {

--- a/app/src/bms_soc.c
+++ b/app/src/bms_soc.c
@@ -13,7 +13,11 @@ void bms_soc_reset(struct bms_context *bms, int percent)
     if (percent <= 100 && percent >= 0) {
         bms->soc = percent;
     }
-    else if (bms->ocv_points != NULL && bms->soc_points != NULL) {
+    else if (bms->ocv_points != NULL && bms->soc_points != NULL
+             && !is_empty((uint8_t *)bms->ocv_points, OCV_POINTS)
+             && !is_empty((uint8_t *)bms->soc_points, OCV_POINTS))
+    {
+        // Executes if both OCV and SOC points are valid pointers and arrays contain non-zero data.
         bms->soc = interpolate(bms->ocv_points, bms->soc_points, OCV_POINTS,
                                bms->ic_data.cell_voltage_avg);
     }

--- a/app/src/data_objects.c
+++ b/app/src/data_objects.c
@@ -21,6 +21,8 @@
 
 extern const struct device *bms_ic;
 extern struct bms_context bms;
+extern float ocv_custom[OCV_POINTS];
+extern float soc_custom[OCV_POINTS];
 
 static char manufacturer[] = "Libre Solar";
 static char device_type[] = DT_PROP(DT_PATH(pcb), type);
@@ -33,6 +35,10 @@ static THINGSET_DEFINE_FLOAT_ARRAY(cell_voltages_arr, 3, bms.ic_data.cell_voltag
 
 static THINGSET_DEFINE_FLOAT_ARRAY(cell_temps_arr, 1, bms.ic_data.cell_temps,
                                    ARRAY_SIZE(bms.ic_data.cell_temps));
+
+static THINGSET_DEFINE_FLOAT_ARRAY(ocv_points_arr, 3, ocv_custom, ARRAY_SIZE(ocv_custom));
+
+static THINGSET_DEFINE_FLOAT_ARRAY(soc_points_arr, 1, soc_custom, ARRAY_SIZE(soc_custom));
 
 // used for xInitConf functions
 static float new_capacity = 0;
@@ -74,6 +80,12 @@ THINGSET_ADD_GROUP(TS_ID_ROOT, APP_ID_CONF, "Conf", &data_objects_update_conf);
 THINGSET_ADD_ITEM_FLOAT(APP_ID_CONF, APP_ID_CONF_NOMINAL_CAPACITY, "sNominalCapacity_Ah",
                         &bms.nominal_capacity_Ah, 1, THINGSET_ANY_R | THINGSET_ANY_W,
                         TS_SUBSET_NVM);
+
+THINGSET_ADD_ITEM_ARRAY(APP_ID_CONF, APP_ID_CONF_OCV_POINTS, "sOcvPoints_V", &ocv_points_arr,
+                        THINGSET_ANY_R | THINGSET_ANY_W, TS_SUBSET_NVM);
+
+THINGSET_ADD_ITEM_ARRAY(APP_ID_CONF, APP_ID_CONF_SOC_POINTS, "sSocPoints_pct", &soc_points_arr,
+                        THINGSET_ANY_R | THINGSET_ANY_W, TS_SUBSET_NVM);
 
 // current limits
 

--- a/app/src/data_objects.h
+++ b/app/src/data_objects.h
@@ -63,6 +63,8 @@
 #define APP_ID_CONF_PRESET_NMC_CAPACITY     0xA1
 #define APP_ID_CONF_PRESET_LFP              0xA2
 #define APP_ID_CONF_PRESET_LFP_CAPACITY     0xA3
+#define APP_ID_CONF_OCV_POINTS              0xB0
+#define APP_ID_CONF_SOC_POINTS              0xB1
 
 /* Measurement data */
 #define APP_ID_MEAS                  0x07

--- a/include/bms/bms.h
+++ b/include/bms/bms.h
@@ -26,10 +26,6 @@ extern "C" {
 /* fixed number of OCV vs. SOC points */
 #define OCV_POINTS 21
 
-static const float soc_pct[OCV_POINTS] = { 100.0F, 95.0F, 90.0F, 85.0F, 80.0F, 85.0F, 70.0F,
-                                           65.0F,  60.0F, 55.0F, 50.0F, 45.0F, 40.0F, 35.0F,
-                                           30.0F,  25.0F, 20.0F, 15.0F, 10.0F, 5.0F,  0.0F };
-
 /**
  * Possible BMS states
  */

--- a/include/helper.h
+++ b/include/helper.h
@@ -58,6 +58,15 @@ float interpolate(const float a[], const float b[], size_t size, float value_a);
  */
 const char *byte2bitstr(uint8_t b);
 
+/**
+ * @brief Check if a buffer is entirely zeroed.
+ *
+ * @param buf A pointer to the buffer (uint8_t*) to be checked.
+ * @param size The size of the buffer in bytes.
+ * @returns true if the buffer is entirely zeroed, false if not.
+ */
+bool is_empty(uint8_t *buf, size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -47,3 +47,15 @@ const char *byte2bitstr(uint8_t b)
 
     return str;
 }
+
+bool is_empty(uint8_t *buf, size_t size)
+{
+
+    for (size_t i = 0; i < size; i++) {
+        if (buf[i] != 0) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/tests/helper/src/is_empty.c
+++ b/tests/helper/src/is_empty.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) The Libre Solar Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "helper.h"
+
+#include <stdio.h>
+
+#include <zephyr/ztest.h>
+
+ZTEST(is_empty, test_empty)
+{
+    float a[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+    zassert_true(is_empty((uint8_t *)a, sizeof(a)));
+
+#if __SIZEOF_POINTER__ == 4
+    uint8_t b[] = { 0, 0, 0 };
+#elif __SIZEOF_POINTER__ == 8
+    uint8_t b[] = { 0, 0, 0, 0, 0, 0, 0 };
+#endif
+    zassert_true(is_empty((uint8_t *)b, sizeof(b)));
+}
+
+ZTEST(is_empty, test_filled_last_element)
+{
+    float a[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0001 };
+    zassert_false(is_empty((uint8_t *)a, sizeof(a)));
+
+#if __SIZEOF_POINTER__ == 4
+    uint8_t b[] = { 0, 0, 1 };
+#elif __SIZEOF_POINTER__ == 8
+    uint8_t b[] = { 0, 0, 0, 0, 0, 0, 1 };
+#endif
+    zassert_false(is_empty((uint8_t *)b, sizeof(b)));
+}
+
+ZTEST(is_empty, test_filled_first_element)
+{
+    float a[] = { 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+    zassert_false(is_empty((uint8_t *)a, sizeof(a)));
+
+#if __SIZEOF_POINTER__ == 4
+    uint8_t b[] = { 1, 0, 0 };
+#elif __SIZEOF_POINTER__ == 8
+    uint8_t b[] = { 1, 0, 0, 0, 0, 0, 0 };
+#endif
+    zassert_false(is_empty((uint8_t *)b, sizeof(b)));
+}
+
+ZTEST(is_empty, test_unaligned_access)
+{
+
+    uint8_t a[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    zassert_true(is_empty(((uint8_t *)a) + 1, sizeof(a) - 1));
+
+    uint8_t b[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+    zassert_false(is_empty(((uint8_t *)b) + 1, sizeof(b) - 1));
+}
+
+ZTEST_SUITE(is_empty, NULL, NULL, NULL, NULL, NULL);

--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
           - tinycrypt
     - name: thingset-zephyr-sdk
       remote: thingset
-      revision: ce07b58d802eb1b56ba9ef82c00ef325b724d827
+      revision: c0783f8f65b184cee5debcb0e33cbb21ea3ae909
       path: thingset-zephyr-sdk
       import:
         name-allowlist:


### PR DESCRIPTION
This PR proposes a solution to fix #15. This includes using the new feature of the ThingSet text mode to add the OCV & SoC points via ThingSet to the config. Additionally, the SoC points will be moved into `bms_common` to harmonize with the OCV points.