### PR TITLE
drivers: bms_ic: change return value for bms_ic_configure

### DIFF
--- a/app/src/data_objects.c
+++ b/app/src/data_objects.c
@@ -269,19 +269,19 @@ void data_objects_update_conf(enum thingset_callback_reason reason)
 
 int32_t bat_preset(enum bms_cell_type type)
 {
-    int err;
+    int ret;
 
     bms_init_config(&bms, type, new_capacity);
 
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_ALL);
+    ret = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_ALL);
 
 #ifdef CONFIG_THINGSET_STORAGE
-    if (err == 0) {
+    if (ret > 0) {
         thingset_storage_save_queued();
     }
 #endif
 
-    return err;
+    return ret;
 }
 
 int32_t bat_preset_nmc()

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -43,7 +43,7 @@ int main(void)
     }
 
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_ALL);
-    if (err != 0) {
+    if (err < 0) {
         LOG_ERR("Failed to configure BMS IC: %d", err);
     }
 

--- a/drivers/bms_ic/bq769x0/bq769x0.c
+++ b/drivers/bms_ic/bq769x0/bq769x0.c
@@ -485,7 +485,7 @@ static int bms_ic_bq769x0_configure(const struct device *dev, struct bms_ic_conf
         return -EIO;
     }
 
-    return (flags == actual_flags) ? 0 : -EINVAL;
+    return (actual_flags != 0) ? actual_flags : -ENOTSUP;
 }
 
 static int bq769x0_read_cell_voltages(const struct device *dev, struct bms_ic_data *ic_data)

--- a/drivers/bms_ic/bq769x2/bq769x2.c
+++ b/drivers/bms_ic/bq769x2/bq769x2.c
@@ -590,7 +590,7 @@ static int bms_ic_bq769x2_configure(const struct device *dev, struct bms_ic_conf
         return -EIO;
     }
 
-    return (flags == actual_flags) ? 0 : -EINVAL;
+    return (actual_flags != 0) ? actual_flags : -ENOTSUP;
 }
 
 static int bq769x2_read_cell_voltages(const struct device *dev, struct bms_ic_data *ic_data)

--- a/drivers/bms_ic/isl94202/isl94202.c
+++ b/drivers/bms_ic/isl94202/isl94202.c
@@ -254,7 +254,7 @@ static int bms_ic_isl94202_configure(const struct device *dev, struct bms_ic_con
         return -EIO;
     }
 
-    return (flags == actual_flags) ? 0 : -EINVAL;
+    return (actual_flags != 0) ? actual_flags : -ENOTSUP;
 }
 
 static int isl94202_read_voltages(const struct device *dev, struct bms_ic_data *ic_data)

--- a/include/drivers/bms_ic.h
+++ b/include/drivers/bms_ic.h
@@ -24,6 +24,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+/* Caution: Maximum number of flags is 31 (BIT(30)) because the flags must fit to an int32_t */
 #define BMS_IC_CONF_VOLTAGE_LIMITS BIT(0)
 #define BMS_IC_CONF_TEMP_LIMITS    BIT(1)
 #define BMS_IC_CONF_CURRENT_LIMITS BIT(2)
@@ -240,8 +241,8 @@ __subsystem struct bms_ic_driver_api
  * @param flags Flags to specify which parts of the configuration should be applied. See
  *              BMS_IC_CONF_* defines for valid flags.
  *
- * @retval 0 for success
- * @retval -EINVAL if not all requested configuration is supported by the IC
+ * @retval appl_flags successfully applied configuration flags (may be different than requested)
+ * @retval -ENOTSUP if none of the requested flags is supported
  * @retval -EIO for communication error
  */
 static inline int bms_ic_configure(const struct device *dev, struct bms_ic_conf *ic_conf,

--- a/tests/bms_ic/bq769x2/src/functions.c
+++ b/tests/bms_ic/bq769x2/src/functions.c
@@ -37,7 +37,7 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
     bms.ic_conf.dis_sc_limit = 10.0F / shunt_res_mohm; // reg value 0 = 10 mV
     bms.ic_conf.dis_sc_delay_us = (2 - 1) * 15;        // 15 us (reg value 1 = no delay)
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(10.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal((2 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
     zassert_equal(0, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9286));
@@ -46,14 +46,14 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
     // min
     bms.ic_conf.dis_sc_delay_us = (1 - 1) * 15; // 15 us (reg value 1 = no delay)
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal((1 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
     zassert_equal(1, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9287));
 
     // too little
     bms.ic_conf.dis_sc_limit = 5.0F / shunt_res_mohm;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(10.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal(0, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9286));
 
@@ -61,7 +61,7 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
     bms.ic_conf.dis_sc_limit = 500.0F / shunt_res_mohm; // reg value 015 = 500 mV
     bms.ic_conf.dis_sc_delay_us = (31 - 1) * 15;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(500.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal((31 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
     zassert_equal(15, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9286));
@@ -71,7 +71,7 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
     bms.ic_conf.dis_sc_limit = 600.0F / shunt_res_mohm;
     bms.ic_conf.dis_sc_delay_us = (32 - 1) * 15;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(500.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal((31 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
     zassert_equal(15, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9286));
@@ -90,7 +90,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     bms.ic_conf.chg_oc_limit = 2 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = lroundf(6.6F + 4 * 3.3F); // 6.6 ms offset
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(lroundf(6.6F + 4 * 3.3F), bms.ic_conf.chg_oc_delay_ms);
     zassert_equal(2, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9280));
@@ -99,7 +99,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     // min
     bms.ic_conf.chg_oc_delay_ms = 6.6F + 1 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(10, bms.ic_conf.chg_oc_delay_ms);
     zassert_equal(1, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9281));
 
@@ -107,7 +107,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     bms.ic_conf.chg_oc_limit = 1 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(10.0F, bms.ic_conf.chg_oc_delay_ms);
     zassert_equal(2, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9280));
@@ -117,7 +117,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     bms.ic_conf.chg_oc_limit = 62 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = 6.6F + 127 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(62 * 2.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.chg_oc_delay_ms);
     zassert_equal(62, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9280));
@@ -127,7 +127,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     bms.ic_conf.chg_oc_limit = 100 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = 6.6F + 150 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(62 * 2.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.chg_oc_delay_ms);
     zassert_equal(62, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9280));
@@ -149,7 +149,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     bms.ic_conf.dis_oc_limit = 4 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 6.6F + 1 * 3.3F; // 6.6 ms offset
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(8.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(10.0F, bms.ic_conf.dis_oc_delay_ms);
     zassert_equal(4, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9282));
@@ -158,7 +158,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     // min
     bms.ic_conf.dis_oc_limit = 2 * 2.0F / shunt_res_mohm;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(2, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9282));
 
@@ -166,7 +166,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     bms.ic_conf.dis_oc_limit = 1 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(10.0F, bms.ic_conf.dis_oc_delay_ms);
     zassert_equal(2, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9282));
@@ -176,7 +176,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     bms.ic_conf.dis_oc_limit = 100 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 6.6F + 127 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(200.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.dis_oc_delay_ms);
     zassert_equal(100, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9282));
@@ -186,7 +186,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     bms.ic_conf.dis_oc_limit = 120 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 6.6F + 150 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(200.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.dis_oc_delay_ms);
     zassert_equal(100, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9282));
@@ -205,7 +205,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_reset = 52 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 74 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(50 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(52 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
     zassert_equal(roundf(74 * 3.3F), bms.ic_conf.cell_uv_delay_ms);
@@ -219,7 +219,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_reset = 22 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 1 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(22 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
     zassert_equal(roundf(1 * 3.3F), bms.ic_conf.cell_uv_delay_ms);
@@ -233,7 +233,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_reset = 18 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 0.0F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(22 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
     zassert_equal(roundf(1 * 3.3F), bms.ic_conf.cell_uv_delay_ms);
@@ -247,7 +247,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_reset = 110 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 2047 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(90 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
     zassert_equal(roundf(2047 * 3.3F), bms.ic_conf.cell_uv_delay_ms);
@@ -261,7 +261,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_reset = 112 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 2048 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(90 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
     zassert_equal(roundf(2047 * 3.3F), bms.ic_conf.cell_uv_delay_ms);
@@ -280,7 +280,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_reset = 84 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 74 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(86 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(84 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
     zassert_equal(roundf(74 * 3.3F), bms.ic_conf.cell_ov_delay_ms);
@@ -294,7 +294,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_reset = 18 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 1 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(18 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
     zassert_equal(roundf(1 * 3.3F), bms.ic_conf.cell_ov_delay_ms);
@@ -308,7 +308,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_reset = 20 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 0.0F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(18 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
     zassert_equal(roundf(1 * 3.3F), bms.ic_conf.cell_ov_delay_ms);
@@ -322,7 +322,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_reset = 90 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 2047 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(90 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
     zassert_equal(roundf(2047 * 3.3F), bms.ic_conf.cell_ov_delay_ms);
@@ -336,7 +336,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_reset = 112 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 2048 * 3.3F;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(108 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
     zassert_equal(roundf(2047 * 3.3F), bms.ic_conf.cell_ov_delay_ms);
@@ -360,7 +360,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.temp_limit_hyst = 5;
 
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(5, bms.ic_conf.temp_limit_hyst);
 
@@ -388,7 +388,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.temp_limit_hyst = 1;
 
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(1, bms.ic_conf.temp_limit_hyst);
 
@@ -425,7 +425,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.temp_limit_hyst = 0;
 
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(1, bms.ic_conf.temp_limit_hyst);
 
@@ -453,7 +453,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.temp_limit_hyst = 20;
 
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(20, bms.ic_conf.temp_limit_hyst);
 
@@ -481,7 +481,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.temp_limit_hyst = 30;
 
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(20, bms.ic_conf.temp_limit_hyst);
 

--- a/tests/bms_ic/isl94202/src/main.c
+++ b/tests/bms_ic/isl94202/src/main.c
@@ -213,21 +213,21 @@ ZTEST(isl94202, test_isl94202_apply_dis_ocp)
     // lower than minimum possible setting
     bms.ic_conf.dis_oc_limit = 1;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(2, bms.ic_conf.dis_oc_limit); // take lowest possible value
     zassert_equal(delay | (0x0 << 12), isl94202_emul_get_word(bms_ic_emul, 0x16));
 
     // something in the middle
     bms.ic_conf.dis_oc_limit = 20;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(16, bms.ic_conf.dis_oc_limit); // round to next lower value
     zassert_equal(delay | (0x4U << 12), isl94202_emul_get_word(bms_ic_emul, 0x16));
 
     // higher than maximum possible setting
     bms.ic_conf.dis_oc_limit = 50;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(48, bms.ic_conf.dis_oc_limit);
     zassert_equal(delay | (0x7U << 12), isl94202_emul_get_word(bms_ic_emul, 0x16));
 }
@@ -243,21 +243,21 @@ ZTEST(isl94202, test_isl94202_apply_chg_ocp)
     // lower than minimum possible setting
     bms.ic_conf.chg_oc_limit = 0.4;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(0.5, bms.ic_conf.chg_oc_limit); // take lowest possible value
     zassert_equal(delay | (0x0 << 12), isl94202_emul_get_word(bms_ic_emul, 0x18));
 
     // something in the middle
     bms.ic_conf.chg_oc_limit = 5.0;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0, bms.ic_conf.chg_oc_limit); // round to next lower value
     zassert_equal(delay | (0x4U << 12), isl94202_emul_get_word(bms_ic_emul, 0x18));
 
     // higher than maximum possible setting
     bms.ic_conf.chg_oc_limit = 50.0;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(12.0, bms.ic_conf.chg_oc_limit);
     zassert_equal(delay | (0x7U << 12), isl94202_emul_get_word(bms_ic_emul, 0x18));
 }
@@ -273,21 +273,21 @@ ZTEST(isl94202, test_isl94202_apply_dis_scp)
     // lower than minimum possible setting
     bms.ic_conf.dis_sc_limit = 5;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(8, bms.ic_conf.dis_sc_limit); // take lowest possible value
     zassert_equal(delay | (0x0 << 12), isl94202_emul_get_word(bms_ic_emul, 0x1A));
 
     // something in the middle
     bms.ic_conf.dis_sc_limit = 40;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(32, bms.ic_conf.dis_sc_limit); // round to next lower value
     zassert_equal(delay | (0x4U << 12), isl94202_emul_get_word(bms_ic_emul, 0x1A));
 
     // higher than maximum possible setting
     bms.ic_conf.dis_sc_limit = 150;
     err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(128, bms.ic_conf.dis_sc_limit);
     zassert_equal(delay | (0x7U << 12), isl94202_emul_get_word(bms_ic_emul, 0x1A));
 }
@@ -299,7 +299,7 @@ ZTEST(isl94202, test_isl94202_apply_cell_ovp)
     bms.ic_conf.cell_ov_delay_ms = 999;
     uint16_t delay = 999 + (1U << 10);
     int err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(0x1E2A, isl94202_emul_get_word(bms_ic_emul, 0x00)); // limit voltage
     zassert_equal(0x0DD4, isl94202_emul_get_word(bms_ic_emul, 0x02)); // recovery voltage
     zassert_equal(delay, isl94202_emul_get_word(bms_ic_emul, 0x10));  // delay
@@ -312,7 +312,7 @@ ZTEST(isl94202, test_isl94202_apply_cell_uvp)
     bms.ic_conf.cell_uv_delay_ms = 2222;
     uint16_t delay = 2222 / 1000 + (2U << 10);
     int err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
-    zassert_equal(0, err);
+    zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(0x18FF, isl94202_emul_get_word(bms_ic_emul, 0x04));
     zassert_equal(0x09FF, isl94202_emul_get_word(bms_ic_emul, 0x06));
     zassert_equal(delay, isl94202_emul_get_word(bms_ic_emul, 0x12));
@@ -322,7 +322,8 @@ ZTEST(isl94202, test_isl94202_apply_chg_ot_limit)
 {
     bms.ic_conf.chg_ot_limit = 55;
     bms.ic_conf.temp_limit_hyst = 5;
-    bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    int err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
     zassert_equal(0x04D2, isl94202_emul_get_word(bms_ic_emul, 0x30)); // datasheet: 0x04B6
     zassert_equal(0x053E, isl94202_emul_get_word(bms_ic_emul, 0x32));
 }
@@ -331,7 +332,8 @@ ZTEST(isl94202, test_isl94202_apply_chg_ut_limit)
 {
     bms.ic_conf.chg_ut_limit = -10;
     bms.ic_conf.temp_limit_hyst = 15;
-    bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    int err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
     zassert_equal(0x0CD1, isl94202_emul_get_word(bms_ic_emul, 0x34)); // datasheet: 0x0BF2
     zassert_equal(0x0BBD, isl94202_emul_get_word(bms_ic_emul, 0x36)); // datasheet: 0x0A93
 }
@@ -340,7 +342,8 @@ ZTEST(isl94202, test_isl94202_apply_dis_ot_limit)
 {
     bms.ic_conf.dis_ot_limit = 55;
     bms.ic_conf.temp_limit_hyst = 5;
-    bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    int err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
     zassert_equal(0x04D2, isl94202_emul_get_word(bms_ic_emul, 0x38)); // datasheet: 0x04B6
     zassert_equal(0x053E, isl94202_emul_get_word(bms_ic_emul, 0x3A));
 }
@@ -349,7 +352,8 @@ ZTEST(isl94202, test_isl94202_apply_dis_ut_limit)
 {
     bms.ic_conf.dis_ut_limit = -10;
     bms.ic_conf.temp_limit_hyst = 15;
-    bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    int err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
     zassert_equal(0x0CD1, isl94202_emul_get_word(bms_ic_emul, 0x3C)); // datasheet: 0x0BF2
     zassert_equal(0x0BBD, isl94202_emul_get_word(bms_ic_emul, 0x3E)); // datasheet: 0x0A93
 }


### PR DESCRIPTION
Not all BMS ICs support all `CONF_` values, which made the call to `bms_ic_configure` fail in the generic BMS main application.

With this API change it is left to the application to judge if the configuration call is considered successful or not.