### PR TITLE
Integrate bms_ic device into bms_context

### DIFF
--- a/app/src/data_objects.c
+++ b/app/src/data_objects.c
@@ -19,7 +19,6 @@
 
 #include <stdio.h>
 
-extern const struct device *bms_ic;
 extern struct bms_context bms;
 extern float ocv_custom[OCV_POINTS];
 extern float soc_custom[OCV_POINTS];
@@ -259,7 +258,7 @@ void data_objects_update_conf(enum thingset_callback_reason reason)
     if (reason == THINGSET_CALLBACK_POST_WRITE) {
         // ToDo: Validate new settings before applying them
 
-        bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_ALL);
+        bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_ALL);
 
 #ifdef CONFIG_THINGSET_STORAGE
         thingset_storage_save_queued();
@@ -273,7 +272,7 @@ int32_t bat_preset(enum bms_cell_type type)
 
     bms_init_config(&bms, type, new_capacity);
 
-    ret = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_ALL);
+    ret = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_ALL);
 
 #ifdef CONFIG_THINGSET_STORAGE
     if (ret > 0) {
@@ -296,7 +295,7 @@ int32_t bat_preset_lfp()
 
 void print_registers()
 {
-    bms_ic_debug_print_mem(bms_ic);
+    bms_ic_debug_print_mem(bms.ic_dev);
 }
 
 void reset_device()
@@ -306,5 +305,5 @@ void reset_device()
 
 void shutdown()
 {
-    bms_ic_set_mode(bms_ic, BMS_IC_MODE_OFF);
+    bms_ic_set_mode(bms.ic_dev, BMS_IC_MODE_OFF);
 }

--- a/include/bms/bms.h
+++ b/include/bms/bms.h
@@ -82,6 +82,9 @@ struct bms_context
     /** Pointer to an array containing the State of Charge points for the OCV. */
     float *soc_points;
 
+    /** BMS IC device pointer */
+    const struct device *ic_dev;
+
     /** BMS IC configuration applied during start-up. */
     struct bms_ic_conf ic_conf;
 

--- a/tests/bms/src/state_machine.c
+++ b/tests/bms/src/state_machine.c
@@ -11,9 +11,9 @@
 #include <stdio.h>
 #include <time.h>
 
-struct bms_context bms;
-
-const struct device *bms_ic = DEVICE_DT_GET(DT_ALIAS(bms_ic));
+struct bms_context bms = {
+    .ic_dev = DEVICE_DT_GET(DT_ALIAS(bms_ic)),
+};
 
 void init_conf()
 {

--- a/tests/bms_ic/bq769x2/src/functions.c
+++ b/tests/bms_ic/bq769x2/src/functions.c
@@ -16,7 +16,6 @@
 #include <stdio.h>
 #include <time.h>
 
-static const struct device *bms_ic = DEVICE_DT_GET(DT_ALIAS(bms_ic));
 static const struct emul *bms_ic_emul = EMUL_DT_GET(DT_ALIAS(bms_ic));
 
 extern struct bms_context bms;
@@ -36,7 +35,7 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
     // default
     bms.ic_conf.dis_sc_limit = 10.0F / shunt_res_mohm; // reg value 0 = 10 mV
     bms.ic_conf.dis_sc_delay_us = (2 - 1) * 15;        // 15 us (reg value 1 = no delay)
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(10.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal((2 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
@@ -45,14 +44,14 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
 
     // min
     bms.ic_conf.dis_sc_delay_us = (1 - 1) * 15; // 15 us (reg value 1 = no delay)
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal((1 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
     zassert_equal(1, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9287));
 
     // too little
     bms.ic_conf.dis_sc_limit = 5.0F / shunt_res_mohm;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(10.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal(0, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9286));
@@ -60,7 +59,7 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
     // max
     bms.ic_conf.dis_sc_limit = 500.0F / shunt_res_mohm; // reg value 015 = 500 mV
     bms.ic_conf.dis_sc_delay_us = (31 - 1) * 15;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(500.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal((31 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
@@ -70,7 +69,7 @@ ZTEST(bq769x2_functions, test_apply_dis_scp)
     // too much
     bms.ic_conf.dis_sc_limit = 600.0F / shunt_res_mohm;
     bms.ic_conf.dis_sc_delay_us = (32 - 1) * 15;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(500.0F / shunt_res_mohm, bms.ic_conf.dis_sc_limit);
     zassert_equal((31 - 1) * 15, bms.ic_conf.dis_sc_delay_us);
@@ -89,7 +88,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     // default
     bms.ic_conf.chg_oc_limit = 2 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = lroundf(6.6F + 4 * 3.3F); // 6.6 ms offset
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(lroundf(6.6F + 4 * 3.3F), bms.ic_conf.chg_oc_delay_ms);
@@ -98,7 +97,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
 
     // min
     bms.ic_conf.chg_oc_delay_ms = 6.6F + 1 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(10, bms.ic_conf.chg_oc_delay_ms);
     zassert_equal(1, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9281));
@@ -106,7 +105,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     // too little
     bms.ic_conf.chg_oc_limit = 1 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(10.0F, bms.ic_conf.chg_oc_delay_ms);
@@ -116,7 +115,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     // max
     bms.ic_conf.chg_oc_limit = 62 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = 6.6F + 127 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(62 * 2.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.chg_oc_delay_ms);
@@ -126,7 +125,7 @@ ZTEST(bq769x2_functions, test_apply_chg_ocp)
     // too much
     bms.ic_conf.chg_oc_limit = 100 * 2.0F / shunt_res_mohm;
     bms.ic_conf.chg_oc_delay_ms = 6.6F + 150 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(62 * 2.0F / shunt_res_mohm, bms.ic_conf.chg_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.chg_oc_delay_ms);
@@ -148,7 +147,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     // default
     bms.ic_conf.dis_oc_limit = 4 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 6.6F + 1 * 3.3F; // 6.6 ms offset
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(8.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(10.0F, bms.ic_conf.dis_oc_delay_ms);
@@ -157,7 +156,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
 
     // min
     bms.ic_conf.dis_oc_limit = 2 * 2.0F / shunt_res_mohm;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(2, bq769x2_emul_get_data_mem(bms_ic_emul, 0x9282));
@@ -165,7 +164,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     // too little
     bms.ic_conf.dis_oc_limit = 1 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(4.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(10.0F, bms.ic_conf.dis_oc_delay_ms);
@@ -175,7 +174,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     // max
     bms.ic_conf.dis_oc_limit = 100 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 6.6F + 127 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(200.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.dis_oc_delay_ms);
@@ -185,7 +184,7 @@ ZTEST(bq769x2_functions, test_apply_dis_ocp)
     // too much
     bms.ic_conf.dis_oc_limit = 120 * 2.0F / shunt_res_mohm;
     bms.ic_conf.dis_oc_delay_ms = 6.6F + 150 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_CURRENT_LIMITS);
     zassert_equal(BMS_IC_CONF_CURRENT_LIMITS, err);
     zassert_equal(200.0F / shunt_res_mohm, bms.ic_conf.dis_oc_limit);
     zassert_equal(lroundf(6.6F + 127 * 3.3F), bms.ic_conf.dis_oc_delay_ms);
@@ -204,7 +203,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_limit = 50 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_reset = 52 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 74 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(50 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(52 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
@@ -218,7 +217,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_limit = 20 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_reset = 22 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 1 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(22 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
@@ -232,7 +231,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_limit = 19 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_reset = 18 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 0.0F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(22 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
@@ -246,7 +245,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_limit = 90 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_reset = 110 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 2047 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(90 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
@@ -260,7 +259,7 @@ ZTEST(bq769x2_functions, test_apply_cell_uvp)
     bms.ic_conf.cell_uv_limit = 91 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_reset = 112 * 50.6F / 1000.0F;
     bms.ic_conf.cell_uv_delay_ms = 2048 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(90 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_limit);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_uv_reset);
@@ -279,7 +278,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_limit = 86 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_reset = 84 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 74 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(86 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(84 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
@@ -293,7 +292,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_limit = 20 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_reset = 18 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 1 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(18 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
@@ -307,7 +306,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_limit = 19 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_reset = 20 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 0.0F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(20 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(18 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
@@ -321,7 +320,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_limit = 110 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_reset = 90 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 2047 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(90 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
@@ -335,7 +334,7 @@ ZTEST(bq769x2_functions, test_apply_cell_ovp)
     bms.ic_conf.cell_ov_limit = 111 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_reset = 112 * 50.6F / 1000.0F;
     bms.ic_conf.cell_ov_delay_ms = 2048 * 3.3F;
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_VOLTAGE_LIMITS);
     zassert_equal(BMS_IC_CONF_VOLTAGE_LIMITS, err);
     zassert_equal(110 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_limit);
     zassert_equal(108 * 50.6F / 1000.0F, bms.ic_conf.cell_ov_reset);
@@ -359,7 +358,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.chg_ut_limit = 0;
     bms.ic_conf.temp_limit_hyst = 5;
 
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
     zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(5, bms.ic_conf.temp_limit_hyst);
@@ -387,7 +386,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.chg_ut_limit = -40;
     bms.ic_conf.temp_limit_hyst = 1;
 
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
     zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(1, bms.ic_conf.temp_limit_hyst);
@@ -415,7 +414,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.chg_ut_limit = -50;
     bms.ic_conf.temp_limit_hyst = 0;
 
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
     zassert_equal(-EIO, err); // should fail
 
     bms.ic_conf.dis_ot_limit = 0;
@@ -424,7 +423,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.chg_ut_limit = -50;
     bms.ic_conf.temp_limit_hyst = 0;
 
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
     zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(1, bms.ic_conf.temp_limit_hyst);
@@ -452,7 +451,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.chg_ut_limit = 100;
     bms.ic_conf.temp_limit_hyst = 20;
 
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
     zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(20, bms.ic_conf.temp_limit_hyst);
@@ -480,7 +479,7 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
     bms.ic_conf.chg_ut_limit = 100;
     bms.ic_conf.temp_limit_hyst = 30;
 
-    err = bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
+    err = bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_TEMP_LIMITS);
     zassert_equal(BMS_IC_CONF_TEMP_LIMITS, err);
 
     zassert_equal(20, bms.ic_conf.temp_limit_hyst);

--- a/tests/bms_ic/bq769x2/src/interface.c
+++ b/tests/bms_ic/bq769x2/src/interface.c
@@ -16,7 +16,6 @@
 #include <stdio.h>
 #include <time.h>
 
-static const struct device *bms_ic = DEVICE_DT_GET(DT_ALIAS(bms_ic));
 static const struct emul *bms_ic_emul = EMUL_DT_GET(DT_ALIAS(bms_ic));
 
 extern struct bms_context bms;
@@ -28,13 +27,13 @@ ZTEST(bq769x2_interface, test_bq769x2_direct_read_u2)
 
     bq769x2_emul_set_direct_mem(bms_ic_emul, 0, 0x00);
     bq769x2_emul_set_direct_mem(bms_ic_emul, 1, 0x00);
-    err = bq769x2_direct_read_u2(bms_ic, 0, &u2);
+    err = bq769x2_direct_read_u2(bms.ic_dev, 0, &u2);
     zassert_equal(0, err);
     zassert_equal(0, u2);
 
     bq769x2_emul_set_direct_mem(bms_ic_emul, 0, 0xFF);
     bq769x2_emul_set_direct_mem(bms_ic_emul, 1, 0xFF);
-    err = bq769x2_direct_read_u2(bms_ic, 0, &u2);
+    err = bq769x2_direct_read_u2(bms.ic_dev, 0, &u2);
     zassert_equal(0, err);
     zassert_equal(UINT16_MAX, u2);
 }
@@ -46,25 +45,25 @@ ZTEST(bq769x2_interface, test_bq769x2_direct_read_i2)
 
     bq769x2_emul_set_direct_mem(bms_ic_emul, 0, 0x00);
     bq769x2_emul_set_direct_mem(bms_ic_emul, 1, 0x00);
-    err = bq769x2_direct_read_i2(bms_ic, 0, &i2);
+    err = bq769x2_direct_read_i2(bms.ic_dev, 0, &i2);
     zassert_equal(0, err);
     zassert_equal(0, i2);
 
     bq769x2_emul_set_direct_mem(bms_ic_emul, 0, 0xFF);
     bq769x2_emul_set_direct_mem(bms_ic_emul, 1, 0xFF);
-    err = bq769x2_direct_read_i2(bms_ic, 0, &i2);
+    err = bq769x2_direct_read_i2(bms.ic_dev, 0, &i2);
     zassert_equal(0, err);
     zassert_equal(-1, i2);
 
     bq769x2_emul_set_direct_mem(bms_ic_emul, 0, 0xFF);
     bq769x2_emul_set_direct_mem(bms_ic_emul, 1, 0x7F);
-    err = bq769x2_direct_read_i2(bms_ic, 0, &i2);
+    err = bq769x2_direct_read_i2(bms.ic_dev, 0, &i2);
     zassert_equal(0, err);
     zassert_equal(INT16_MAX, i2);
 
     bq769x2_emul_set_direct_mem(bms_ic_emul, 0, 0x00);
     bq769x2_emul_set_direct_mem(bms_ic_emul, 1, 0x80);
-    err = bq769x2_direct_read_i2(bms_ic, 0, &i2);
+    err = bq769x2_direct_read_i2(bms.ic_dev, 0, &i2);
     zassert_equal(0, err);
     zassert_equal(INT16_MIN, i2);
 }
@@ -79,7 +78,7 @@ ZTEST(bq769x2_interface, test_bq769x2_subcmd_cmd_only)
     bq769x2_emul_set_direct_mem(bms_ic_emul, 0x3F, 0xFF);
 
     // write subcmd register via API
-    int err = bq769x2_subcmd_cmd_only(bms_ic, 0x0012);
+    int err = bq769x2_subcmd_cmd_only(bms.ic_dev, 0x0012);
     zassert_equal(0, err);
 
     zassert_equal(subcmd_expected[0], bq769x2_emul_get_direct_mem(bms_ic_emul, 0x3E));
@@ -97,7 +96,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_read_u1)
 
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0xFF);
 
-    int err = bq769x2_datamem_read_u1(bms_ic, 0x9180, &value);
+    int err = bq769x2_datamem_read_u1(bms.ic_dev, 0x9180, &value);
     zassert_equal(0, err);
     zassert_equal(UINT8_MAX, value);
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
@@ -114,7 +113,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_read_u2)
 
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0x00 + 0xFF);
 
-    int err = bq769x2_datamem_read_u2(bms_ic, 0x9180, &value);
+    int err = bq769x2_datamem_read_u2(bms.ic_dev, 0x9180, &value);
     zassert_equal(0, err);
     zassert_equal(0xFF00, value);
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
@@ -131,7 +130,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_read_i1)
 
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0x80);
 
-    int err = bq769x2_datamem_read_i1(bms_ic, 0x9180, &value);
+    int err = bq769x2_datamem_read_i1(bms.ic_dev, 0x9180, &value);
     zassert_equal(0, err);
     zassert_equal(INT8_MIN, value);
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
@@ -148,7 +147,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_read_i2)
 
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0x00 + 0x80);
 
-    int err = bq769x2_datamem_read_i2(bms_ic, 0x9180, &value);
+    int err = bq769x2_datamem_read_i2(bms.ic_dev, 0x9180, &value);
     zassert_equal(0, err);
     zassert_equal(INT16_MIN, value);
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
@@ -165,7 +164,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_read_f4)
 
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0xB6 + 0xF3 + 0x9D + 0x3F);
 
-    int err = bq769x2_datamem_read_f4(bms_ic, 0x9180, &value);
+    int err = bq769x2_datamem_read_f4(bms.ic_dev, 0x9180, &value);
     zassert_equal(0, err);
     zassert_equal(1.234F, value);
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
@@ -177,16 +176,16 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_u1)
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0xFF);
     uint8_t len_expected = 4 + sizeof(data_expected);
 
-    bq769x2_config_update_mode(bms_ic, true);
+    bq769x2_config_update_mode(bms.ic_dev, true);
 
-    int err = bq769x2_datamem_write_u1(bms_ic, 0x9180, UINT8_MAX);
+    int err = bq769x2_datamem_write_u1(bms.ic_dev, 0x9180, UINT8_MAX);
     zassert_equal(0, err);
 
     zassert_equal(data_expected[0], bq769x2_emul_get_direct_mem(bms_ic_emul, 0x40));
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
     zassert_equal(len_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x61));
 
-    bq769x2_config_update_mode(bms_ic, false);
+    bq769x2_config_update_mode(bms.ic_dev, false);
 }
 
 ZTEST(bq769x2_interface, test_bq769x2_datamem_write_u2)
@@ -195,9 +194,9 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_u2)
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0xFF);
     uint8_t len_expected = 4 + sizeof(data_expected);
 
-    bq769x2_config_update_mode(bms_ic, true);
+    bq769x2_config_update_mode(bms.ic_dev, true);
 
-    int err = bq769x2_datamem_write_u2(bms_ic, 0x9180, 0xFF00);
+    int err = bq769x2_datamem_write_u2(bms.ic_dev, 0x9180, 0xFF00);
     zassert_equal(0, err);
 
     zassert_equal(data_expected[0], bq769x2_emul_get_direct_mem(bms_ic_emul, 0x40));
@@ -205,7 +204,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_u2)
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
     zassert_equal(len_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x61));
 
-    bq769x2_config_update_mode(bms_ic, false);
+    bq769x2_config_update_mode(bms.ic_dev, false);
 }
 
 ZTEST(bq769x2_interface, test_bq769x2_datamem_write_i1)
@@ -214,16 +213,16 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_i1)
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0x80);
     uint8_t len_expected = 4 + sizeof(data_expected);
 
-    bq769x2_config_update_mode(bms_ic, true);
+    bq769x2_config_update_mode(bms.ic_dev, true);
 
-    int err = bq769x2_datamem_write_i1(bms_ic, 0x9180, INT8_MIN);
+    int err = bq769x2_datamem_write_i1(bms.ic_dev, 0x9180, INT8_MIN);
     zassert_equal(0, err);
 
     zassert_equal(data_expected[0], bq769x2_emul_get_direct_mem(bms_ic_emul, 0x40));
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
     zassert_equal(len_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x61));
 
-    bq769x2_config_update_mode(bms_ic, false);
+    bq769x2_config_update_mode(bms.ic_dev, false);
 }
 
 ZTEST(bq769x2_interface, test_bq769x2_datamem_write_i2)
@@ -232,9 +231,9 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_i2)
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0x00 + 0x80);
     uint8_t len_expected = 4 + sizeof(data_expected);
 
-    bq769x2_config_update_mode(bms_ic, true);
+    bq769x2_config_update_mode(bms.ic_dev, true);
 
-    int err = bq769x2_datamem_write_i2(bms_ic, 0x9180, INT16_MIN);
+    int err = bq769x2_datamem_write_i2(bms.ic_dev, 0x9180, INT16_MIN);
     zassert_equal(0, err);
 
     zassert_equal(data_expected[0], bq769x2_emul_get_direct_mem(bms_ic_emul, 0x40));
@@ -242,7 +241,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_i2)
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
     zassert_equal(len_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x61));
 
-    bq769x2_config_update_mode(bms_ic, false);
+    bq769x2_config_update_mode(bms.ic_dev, false);
 }
 
 ZTEST(bq769x2_interface, test_bq769x2_datamem_write_f4)
@@ -251,9 +250,9 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_f4)
     uint8_t chk_expected = (uint8_t) ~(0x91 + 0x80 + 0xB6 + 0xF3 + 0x9D + 0x3F);
     uint8_t len_expected = 4 + sizeof(data_expected);
 
-    bq769x2_config_update_mode(bms_ic, true);
+    bq769x2_config_update_mode(bms.ic_dev, true);
 
-    int err = bq769x2_datamem_write_f4(bms_ic, 0x9180, 1.234F);
+    int err = bq769x2_datamem_write_f4(bms.ic_dev, 0x9180, 1.234F);
     zassert_equal(0, err);
 
     zassert_equal(data_expected[0], bq769x2_emul_get_direct_mem(bms_ic_emul, 0x40));
@@ -263,7 +262,7 @@ ZTEST(bq769x2_interface, test_bq769x2_datamem_write_f4)
     zassert_equal(chk_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x60));
     zassert_equal(len_expected, bq769x2_emul_get_direct_mem(bms_ic_emul, 0x61));
 
-    bq769x2_config_update_mode(bms_ic, false);
+    bq769x2_config_update_mode(bms.ic_dev, false);
 }
 
 static void *bq769x2_setup(void)

--- a/tests/bms_ic/common/bms_setup.c
+++ b/tests/bms_ic/common/bms_setup.c
@@ -9,9 +9,9 @@
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 
-struct bms_context bms;
-
-const struct device *bms_ic = DEVICE_DT_GET(DT_ALIAS(bms_ic));
+struct bms_context bms = {
+    .ic_dev = DEVICE_DT_GET(DT_ALIAS(bms_ic)),
+};
 
 float OCV[] = { // 100, 95, ..., 0 %
     3.392, 3.314, 3.309, 3.308, 3.304, 3.296, 3.283, 3.275, 3.271, 3.268, 3.265,
@@ -20,9 +20,9 @@ float OCV[] = { // 100, 95, ..., 0 %
 
 void common_setup_bms_defaults()
 {
-    bms_ic_assign_data(bms_ic, &bms.ic_data);
+    bms_ic_assign_data(bms.ic_dev, &bms.ic_data);
 
-    bms_ic_set_mode(bms_ic, BMS_IC_MODE_ACTIVE);
+    bms_ic_set_mode(bms.ic_dev, BMS_IC_MODE_ACTIVE);
 
     bms.ic_conf.dis_sc_limit = 35.0;
     bms.ic_conf.dis_sc_delay_us = 200;
@@ -55,10 +55,10 @@ void common_setup_bms_defaults()
     bms.ic_conf.bal_cell_voltage_diff = 0.01;
     bms.ic_conf.bal_idle_current = 0.1;
 
-    bms_ic_configure(bms_ic, &bms.ic_conf, BMS_IC_CONF_ALL);
+    bms_ic_configure(bms.ic_dev, &bms.ic_conf, BMS_IC_CONF_ALL);
 
-    bms_ic_read_data(bms_ic, BMS_IC_DATA_CELL_VOLTAGES);
+    bms_ic_read_data(bms.ic_dev, BMS_IC_DATA_CELL_VOLTAGES);
 
-    bms_ic_set_switches(bms_ic, BMS_SWITCH_DIS, true);
-    bms_ic_set_switches(bms_ic, BMS_SWITCH_CHG, true);
+    bms_ic_set_switches(bms.ic_dev, BMS_SWITCH_DIS, true);
+    bms_ic_set_switches(bms.ic_dev, BMS_SWITCH_CHG, true);
 }


### PR DESCRIPTION
Previously, both the `bms_ic` and the `bms_context` had to be shared between different files, even though the `bms_ic` dev logically belongs to the `bms_context`.

This commit adds a `const struct device *ic_dev` to the `bms_context`, solving the issue.