### PR TITLE
drivers: bms_ic: rework balancing control

### DIFF
--- a/app/src/bms_common.c
+++ b/app/src/bms_common.c
@@ -45,6 +45,7 @@ void bms_init_config(struct bms_context *bms, enum bms_cell_type type, float nom
     bms->chg_enable = true;
     bms->dis_enable = true;
 
+    bms->ic_conf.auto_balancing = true;
     bms->ic_conf.bal_idle_delay = 1800;         // default: 30 minutes
     bms->ic_conf.bal_idle_current = 0.1F;       // A
     bms->ic_conf.bal_cell_voltage_diff = 0.01F; // 10 mV

--- a/drivers/bms_ic/bq769x2/bq769x2.c
+++ b/drivers/bms_ic/bq769x2/bq769x2.c
@@ -397,9 +397,9 @@ static int bq769x2_configure_balancing(const struct device *dev, struct bms_ic_c
     /* enable CB_RLX and CB_CHG */
     err |= bq769x2_datamem_write_u1(dev, BQ769X2_SET_CBAL_CONF, 0x03);
 
-    ic_conf->bal_cell_voltage_min = ic_conf->bal_cell_voltage_min;
-    ic_conf->bal_cell_voltage_diff = ic_conf->bal_cell_voltage_diff;
-    ic_conf->bal_idle_current = ic_conf->bal_idle_current;
+    ic_conf->bal_cell_voltage_min = (float)cell_voltage_min * 0.001F;
+    ic_conf->bal_cell_voltage_diff = (float)cell_voltage_delta * 0.001F;
+    ic_conf->bal_idle_current = (float)idle_current_threshold * 0.001F;
 
     return err == 0 ? 0 : -EIO;
 }

--- a/drivers/bms_ic/bq769x2/bq769x2_priv.h
+++ b/drivers/bms_ic/bq769x2/bq769x2_priv.h
@@ -70,6 +70,7 @@ struct bms_ic_bq769x2_data
 {
     struct bms_ic_data *ic_data;
     bool config_update_mode_enabled;
+    bool auto_balancing;
 };
 
 #endif /* DRIVERS_BMS_IC_BMS_IC_BQ769X2_PRIV_H_ */

--- a/drivers/bms_ic/isl94202/isl94202_priv.h
+++ b/drivers/bms_ic/isl94202/isl94202_priv.h
@@ -34,7 +34,10 @@ struct bms_ic_isl94202_config
 struct bms_ic_isl94202_data
 {
     struct bms_ic_data *ic_data;
+    const struct device *dev;
+    struct k_work_delayable balancing_work;
     uint8_t fet_state;
+    bool auto_balancing;
 };
 
 #endif /* DRIVERS_BMS_IC_BMS_IC_ISL94202_PRIV_H_ */

--- a/include/drivers/bms_ic.h
+++ b/include/drivers/bms_ic.h
@@ -41,9 +41,6 @@ extern "C" {
 #define BMS_IC_DATA_ERROR_FLAGS   BIT(5)
 #define BMS_IC_DATA_ALL           GENMASK(5, 0)
 
-#define BMS_IC_BALANCING_OFF  (0)
-#define BMS_IC_BALANCING_AUTO (UINT32_MAX)
-
 /**
  * BMS IC operation modes
  */
@@ -119,6 +116,8 @@ struct bms_ic_conf
     float bal_idle_current;
     /** Minimum idle duration before balancing (s) */
     uint16_t bal_idle_delay;
+    /** Enable/disable automatic balancing (controlled by the IC or driver) */
+    bool auto_balancing;
 
     /* Built-in voltage regulator settings */
     /**
@@ -318,13 +317,14 @@ static inline int bms_ic_set_switches(const struct device *dev, uint8_t switches
 #endif
 
 /**
- * @brief Update the balancing operation of the IC.
+ * @brief Manually set balancing switches of the IC.
  *
  * @param dev Pointer to the device structure for the driver instance.
- * @param cells Bitset defining the cell(s) to be balanced. Set to BMS_IC_BALANCING_OFF to disable
- *              balancing and BMS_IC_BALANCING_AUTO to enable automatic balancing.
+ * @param cells Bitset defining the cell(s) to be balanced. Set to 0 to disable balancing.
  *
- * @return 0 for success or negative error code otherwise.
+ * @retval 0 for success
+ * @retval -EBUSY if automatic balancing was enabled through bms_ic_configure
+ * @return -EINVAL if an invalid set of cells is requested to be balanced
  */
 static inline int bms_ic_balance(const struct device *dev, uint32_t cells)
 {


### PR DESCRIPTION
Switching between automatic and manual balancing requires to enter config update mode for the bq769x2. During config update mode, all measurements and protections are disabled. As also stated in the datasheet, this mode should only be activated for initial configuration (before actual operation of the battery).

This means that we have to decide regarding automatic or manual balancing operation at the very beginning and only allow manually setting the switches if we are not in automatic balancing mode.

This behavior makes sense also for other drivers than the bq769x2, as an application firmware would either control balancing itself or let the chip/driver control balancing autonomously. It is not required to switch between automatic and manual balancing while the BMS is in operation.