### PR TITLE
Changed dchg-pin-config value 

### DIFF
--- a/boards/riscv/bms_c1/bms_c1.dts
+++ b/boards/riscv/bms_c1/bms_c1.dts
@@ -95,7 +95,7 @@
 		/* all NTCs configured with 18k pull-up */
 		ts1-pin-config = <0x07>;
 		ts3-pin-config = <0x07>;
-		dchg-pin-config = <0x07>;
+		dchg-pin-config = <0x0F>;
 		cell-temp-pins = <BQ769X2_PIN_TS1 BQ769X2_PIN_TS3>;
 		fet-temp-pin = <BQ769X2_PIN_DCHG>;
 		board-max-current = <100>;


### PR DESCRIPTION
Changed dchg-pin-config value from 0x07 to 0x0F to configure this pin for measuring the temperature of FETs on the board. See section 6.4 of bq76952 technical ref. Closes #61 