### PR TITLE
Bump ThingSet Zephyr SDK to fix multi-frame reports

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -23,7 +23,7 @@ manifest:
           - tinycrypt
     - name: thingset-zephyr-sdk
       remote: thingset
-      revision: c0783f8f65b184cee5debcb0e33cbb21ea3ae909
+      revision: 46c6e19af7ef7e5badc1ba5a900f6fde92e08fb2
       path: thingset-zephyr-sdk
       import:
         name-allowlist:


### PR DESCRIPTION
Opening a PR for information/documentation purposes.

This change is breaking the multi-frame reports sent out via CAN.

Related PRs:

- https://github.com/ThingSet/thingset-zephyr-sdk/pull/27
- https://github.com/ThingSet/thingset.github.io/pull/30