### PR TITLE
bq769x2: fix cell detection for floating voltages

### DIFF
--- a/drivers/bms_ic/bq769x2/bq769x2.c
+++ b/drivers/bms_ic/bq769x2/bq769x2.c
@@ -123,7 +123,7 @@ static int bq769x2_detect_cells(const struct device *dev)
     const struct bms_ic_bq769x2_config *config = dev->config;
     uint8_t conn_cells = 0;
     uint16_t vcell_mode = 0;
-    uint16_t voltage = UINT16_MAX; /* init with implausible value */
+    int16_t voltage = INT16_MAX; /* init with implausible value */
     uint32_t stack_voltage_calc = 0;
     int err = 0;
 


### PR DESCRIPTION
If no cell is connected, the connectors are usually shorted. However, the measured voltage may not be exactly 0, often floating around 0. This can result in negative values being measured, causing incorrect cell detection. The Technical Reference Manual (Table 12-1) describes these values as i2. By using int16_t for voltage, negative values are correctly read as -1 instead of 65535, improving detection accuracy.