### PR TITLE
[USER MANUAL] Added table containing board-names & revisions

### DIFF
--- a/docs/src/dev/building_flashing.rst
+++ b/docs/src/dev/building_flashing.rst
@@ -77,7 +77,7 @@ for more details regarding board revision handling in Zephyr.
 +--------------------------------+----------------------+----------------+
 
 (*) Only for BMS-8S50-IC with STM32F072 MCU.
-Supported hardware is further described in :doc:`../supported_hardware`. 
+Supported hardware is further described in :doc:`../supported_hardware`.
 
 Flash with specific debug probe (runner), e.g. J-Link:
 

--- a/docs/src/dev/building_flashing.rst
+++ b/docs/src/dev/building_flashing.rst
@@ -16,29 +16,6 @@ firmware, so we go into that directory first.
 
     cd app
 
-
-Boards with STM32 MCU
-"""""""""""""""""""""
-
-Initial board selection (see ``boards`` subfolder for correct names):
-
-.. code-block:: bash
-
-    west build -b <board-name>@<revision>
-
-The appended ``@<revision>`` specifies the board version according to the table in
-:doc:`../supported_hardware`. It can be omitted if only a single board revision is available or if
-the default (most recent) version should be used. See also
-`here <https://docs.zephyrproject.org/latest/application/index.html#application-board-version>`_
-for more details regarding board revision handling in Zephyr.
-
-Flash with specific debug probe (runner), e.g. J-Link:
-
-.. code-block:: bash
-
-    west flash -r jlink
-
-
 Boards with ESP32 MCU
 """""""""""""""""""""
 
@@ -55,6 +32,12 @@ Afterwards you can build and flash the firmware the same way as for STM32:
     west build -b <board-name>@<revision>
     west flash
 
++--------------------------------+----------------------+----------------+
+| Board with ESP32 MCU           | board-name           | revision       |
++================================+======================+================+
+| Libre Solar `BMS-C1`_          | bms_c1               | 0.4, 0.3       |
++--------------------------------+----------------------+----------------+
+
 For monitoring the serial monitor built into the Espressif toolchain can be used with:
 
 .. code-block:: bash
@@ -62,3 +45,43 @@ For monitoring the serial monitor built into the Espressif toolchain can be used
     west espressif monitor
 
 Press Ctrl+T followed by X to exit.
+
+Boards with STM32 MCU
+"""""""""""""""""""""
+
+Initial board selection (see ``boards`` subfolder for correct names):
+
+.. code-block:: bash
+
+    west build -b <board-name>@<revision>
+
+``<board-name>`` should be one of the listed board in the table below.
+The appended ``@<revision>`` specifies the board version.
+Revision can be omitted if only a single board revision is available or if
+the default (most recent) version should be used. See also
+`here <https://docs.zephyrproject.org/latest/application/index.html#application-board-version>`_
+for more details regarding board revision handling in Zephyr.
+
++--------------------------------+----------------------+----------------+
+| Board with STM32 MCU           | board-name           | revision       |
++================================+======================+================+
+| Libre Solar `BMS-5S50-SC`_     | bms_5s50_sc          | 0.1            |
++--------------------------------+----------------------+----------------+
+| Libre Solar `BMS-15S80-SC`_    | bms_15s80_sc         | 0.1            |
++--------------------------------+----------------------+----------------+
+| Libre Solar `BMS-16S100-SC`_   | bms_16s100_sc        | 0.2            |
++--------------------------------+----------------------+----------------+
+| Libre Solar `BMS-8S50-IC`_     | bms_8s50_ic          | 0.2, 0.1       |
++--------------------------------+----------------------+----------------+
+| Libre Solar `BMS-8S50-IC`_ *   | bms_8s50_ic_f072     | 0.1            |
++--------------------------------+----------------------+----------------+
+
+(*) Only for BMS-8S50-IC with STM32F072 MCU.
+Supported hardware is further described in :doc:`../supported_hardware`. 
+
+Flash with specific debug probe (runner), e.g. J-Link:
+
+.. code-block:: bash
+
+    west flash -r jlink
+

--- a/docs/src/dev/building_flashing.rst
+++ b/docs/src/dev/building_flashing.rst
@@ -84,4 +84,3 @@ Flash with specific debug probe (runner), e.g. J-Link:
 .. code-block:: bash
 
     west flash -r jlink
-


### PR DESCRIPTION
When following the manual to flash the newest firmware I found it confusing to look in a separate page to check which boards were available. 
`board-name` and `revision` where not listed properly, or at least not with west syntax (lower case, underscores). 
This PR fixes that. 

I also propose to switch sections ESP32 / STM32 as the newest hardware in based on ESP32, and most likely STM32 related section is to be legacy compatible but does not concern most newcomers.