### PR TITLE
bms-c1 v0.4: Fix CAN sending by deactivating RS485 transceiver

### DIFF
--- a/boards/riscv/bms_c1/bms_c1_0_4_0.overlay
+++ b/boards/riscv/bms_c1/bms_c1_0_4_0.overlay
@@ -11,6 +11,14 @@
 	};
 };
 
+&gpio0 {
+	deactivate-rs485 {
+		gpio-hog;
+		gpios = <6 GPIO_ACTIVE_HIGH>, <7 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
 &pinctrl {
 	i2c0_default: i2c0_default {
 		group1 {


### PR DESCRIPTION
When using CAN, it is necessary to deactivate the RS485 transceiver. This commit sets the DE and RE_NOT pins to the correct states to deactivate the transceiver as described in chapter "9.4 Device Functional Modes" in the "SN65HVD7x 3.3-V Supply RS-485 With IEC ESD protection" datasheet.