### PR TITLE
bq769x2: Add support for configuring REG0 (pre-regulator)

### DIFF
--- a/drivers/bms_ic/bq769x2/bq769x2_priv.h
+++ b/drivers/bms_ic/bq769x2/bq769x2_priv.h
@@ -59,6 +59,7 @@ struct bms_ic_bq769x2_config
     uint8_t fet_temp_pin;
     bool crc_enabled;
     bool auto_pdsg;
+    uint8_t reg0_config;
     uint8_t reg12_config;
     bq769x2_write_bytes_t write_bytes;
     bq769x2_read_bytes_t read_bytes;

--- a/dts/bindings/bms_ic/ti,bq769x2-common.yaml
+++ b/dts/bindings/bms_ic/ti,bq769x2-common.yaml
@@ -105,6 +105,14 @@ properties:
     description: |
       Enable automatic pre-discharge (bus precharge) before switching on DSG FETs.
 
+  reg0-config:
+    type: int
+    default: 0
+    description: |
+      Configuration of the REG0 Config Register. REG0 is the pre-regulator for REG1/2 and must be
+      enabled if REG1 or REG2 are used and REGIN is not supplied externally.
+      Valid values: 0 and 1
+
   reg12-config:
     type: int
     default: 0


### PR DESCRIPTION
It was not possible to enable the pre-regulator REG0, which is required in most cases when REG1 and REG2 are needed. In addition to that, `bq769x2_configure_voltage_regs` did not correctly update the actually configured regulators.

Fixes #85