### PR TITLE
Fix the default soc_points value

### DIFF
--- a/app/src/bms_common.c
+++ b/app/src/bms_common.c
@@ -30,7 +30,7 @@ static const float ocv_lto[NUM_OCV_POINTS] = {
 };
 
 static const float soc_default[NUM_OCV_POINTS] = {
-    100.0F, 95.0F, 90.0F, 85.0F, 80.0F, 85.0F, 70.0F, 65.0F, 60.0F, 55.0F, 50.0F,
+    100.0F, 95.0F, 90.0F, 85.0F, 80.0F, 75.0F, 70.0F, 65.0F, 60.0F, 55.0F, 50.0F,
     45.0F,  40.0F, 35.0F, 30.0F, 25.0F, 20.0F, 15.0F, 10.0F, 5.0F,  0.0F,
 };
 


### PR DESCRIPTION
There is typo on the variable, which will cause issue when mapping soc between 80-70%