### PR TITLE
Update ThingSet SDK to fix stalled MCU on BMS C1

### DIFF
--- a/app/src/data_objects.c
+++ b/app/src/data_objects.c
@@ -258,7 +258,8 @@ THINGSET_ADD_ITEM_BOOL(APP_ID_INPUT, APP_ID_INPUT_CHG_ENABLE, "wChgEnable", &bms
 THINGSET_ADD_ITEM_BOOL(APP_ID_INPUT, APP_ID_INPUT_DIS_ENABLE, "wDisEnable", &bms.dis_enable,
                        THINGSET_ANY_R | THINGSET_ANY_W, 0);
 
-void data_objects_update_conf(enum thingset_callback_reason reason)
+int data_objects_update_conf(enum thingset_callback_reason reason,
+                             const struct thingset_data_object *obj)
 {
     if (reason == THINGSET_CALLBACK_POST_WRITE) {
         // ToDo: Validate new settings before applying them
@@ -269,6 +270,7 @@ void data_objects_update_conf(enum thingset_callback_reason reason)
         thingset_storage_save_queued(true);
 #endif
     }
+    return 0;
 }
 
 int32_t bat_preset(enum bms_cell_type type)

--- a/app/src/data_objects.h
+++ b/app/src/data_objects.h
@@ -93,7 +93,8 @@
 /**
  * Callback function to be called when conf values were changed
  */
-void data_objects_update_conf(enum thingset_callback_reason reason);
+int data_objects_update_conf(enum thingset_callback_reason reason,
+                             const struct thingset_data_object *obj);
 
 /**
  * Callback function to apply preset parameters for NMC type via ThingSet

--- a/docs/src/dev/customization.rst
+++ b/docs/src/dev/customization.rst
@@ -74,11 +74,12 @@ board-specific ``.conf`` file:
 
     CONFIG_THINGSET_REPORTING_LIVE_ENABLE_PRESET=n
 
-The default period for data publication can be changed with the following Kconfig option:
+The default period for data publication can be changed with the following Kconfig option (value in
+milliseconds):
 
 .. code-block:: bash
 
-    CONFIG_THINGSET_REPORTING_LIVE_PERIOD_PRESET=10
+    CONFIG_THINGSET_REPORTING_LIVE_PERIOD_PRESET=10000
 
 Shields for UEXT connector
 --------------------------

--- a/west.yml
+++ b/west.yml
@@ -26,7 +26,7 @@ manifest:
           - zcbor
     - name: thingset-zephyr-sdk
       remote: thingset
-      revision: b9d300777b669cf3830556cb1a7b41c59b0608e2
+      revision: 5d5c6b031ba543d67a3dc6904ccfc987ebdadc52
       path: thingset-zephyr-sdk
       import:
         name-allowlist:


### PR DESCRIPTION
The reason was that due to an update in the unit of the live reporting
period the BMS would try to send out reports in 1 ms intervals if it
had a reporting period from previous firmware versions stored in the
flash.

See also original ThingSet SDK PR: https://github.com/ThingSet/thingset-zephyr-sdk/pull/66

Fixes #91 