### PR TITLE
bq769x2: Add shunt temperature sensing via configurable pin

### DIFF
--- a/app/src/data_objects.c
+++ b/app/src/data_objects.c
@@ -224,6 +224,11 @@ THINGSET_ADD_ITEM_FLOAT(APP_ID_MEAS, APP_ID_MEAS_MOSFET_TEMP, "rMOSFETTemp_degC"
                         &bms.ic_data.mosfet_temp, 1, THINGSET_ANY_R, TS_SUBSET_LIVE);
 #endif
 
+#ifdef CONFIG_BMS_IC_CURRENT_MONITORING
+THINGSET_ADD_ITEM_FLOAT(APP_ID_MEAS, APP_ID_MEAS_SHUNT_TEMP, "rShuntTemp_degC",
+                        &bms.ic_data.shunt_temp, 1, THINGSET_ANY_R, TS_SUBSET_LIVE);
+#endif
+
 THINGSET_ADD_ITEM_FLOAT(APP_ID_MEAS, APP_ID_MEAS_SOC, "rSOC_pct", &bms.soc, 1, THINGSET_ANY_R,
                         TS_SUBSET_LIVE);
 

--- a/app/src/data_objects.h
+++ b/app/src/data_objects.h
@@ -76,6 +76,7 @@
 #define APP_ID_MEAS_IC_TEMP          0x75
 #define APP_ID_MEAS_MCU_TEMP         0x76
 #define APP_ID_MEAS_MOSFET_TEMP      0x77
+#define APP_ID_MEAS_SHUNT_TEMP       0x78
 #define APP_ID_MEAS_SOC              0x7C
 #define APP_ID_MEAS_ERROR_FLAGS      0x7E
 #define APP_ID_MEAS_BMS_STATE        0x7F

--- a/boards/libresolar/bms_c1/bms_c1.dts
+++ b/boards/libresolar/bms_c1/bms_c1.dts
@@ -92,9 +92,11 @@
 		/* all NTCs configured with 18k pull-up */
 		ts1-pin-config = <0x07>;
 		ts3-pin-config = <0x07>;
+		dfetoff-pin-config = <0x07>;
 		dchg-pin-config = <0x0F>;
 		cell-temp-pins = <BQ769X2_PIN_TS1 BQ769X2_PIN_TS3>;
 		fet-temp-pin = <BQ769X2_PIN_DCHG>;
+		shunt-temp-pin = <BQ769X2_PIN_DFETOFF>;
 		board-max-current = <100>;
 		shunt-resistor-uohm = <300>;
 		status = "okay";

--- a/drivers/bms_ic/bq769x2/bq769x2.c
+++ b/drivers/bms_ic/bq769x2/bq769x2.c
@@ -725,6 +725,15 @@ static int bq769x2_read_temperatures(const struct device *dev, struct bms_ic_dat
     }
 #endif
 
+#ifdef CONFIG_BMS_IC_CURRENT_MONITORING
+    /* Read shunt temperature if a pin was defined in Devicetree */
+    if (config->shunt_temp_pin < ARRAY_SIZE(config->pin_config)) {
+        err |= bq769x2_direct_read_i2(dev, BQ769X2_CMD_TEMP_CFETOFF + config->shunt_temp_pin * 2U,
+                                      &temp);
+        ic_data->shunt_temp = (temp * 0.1F) - 273.15F;
+    }
+#endif
+
     return err == 0 ? 0 : -EIO;
 }
 
@@ -1004,6 +1013,7 @@ static const struct bms_ic_driver_api bq769x2_driver_api = {
         .cell_temp_pins = DT_INST_PROP(index, cell_temp_pins),                             \
         .num_cell_temps = DT_INST_PROP_LEN(index, cell_temp_pins),                         \
         .fet_temp_pin = DT_INST_PROP_OR(index, fet_temp_pin, UINT8_MAX),                   \
+        .shunt_temp_pin = DT_INST_PROP_OR(index, shunt_temp_pin, UINT8_MAX),               \
         .crc_enabled = DT_INST_PROP(index, crc_enabled),                                   \
         .auto_pdsg = DT_INST_PROP(index, auto_pdsg),                                       \
         .reg0_config = DT_INST_PROP(index, reg0_config),                                   \

--- a/drivers/bms_ic/bq769x2/bq769x2_priv.h
+++ b/drivers/bms_ic/bq769x2/bq769x2_priv.h
@@ -57,6 +57,7 @@ struct bms_ic_bq769x2_config
     uint8_t cell_temp_pins[CONFIG_BMS_IC_MAX_THERMISTORS];
     uint8_t num_cell_temps;
     uint8_t fet_temp_pin;
+    uint8_t shunt_temp_pin;
     bool crc_enabled;
     bool auto_pdsg;
     uint8_t reg0_config;

--- a/dts/bindings/bms_ic/ti,bq769x2-common.yaml
+++ b/dts/bindings/bms_ic/ti,bq769x2-common.yaml
@@ -100,6 +100,24 @@ properties:
 
       See include/zephyr/dt-bindings/bms_ic/bq769x2.h for allowed values.
 
+  shunt-temp-pin:
+    type: int
+    enum:
+      - 0 # CFETOFF
+      - 1 # DFETOFF
+      - 2 # ALERT
+      - 3 # TS1
+      - 4 # TS2
+      - 5 # TS3
+      - 6 # HDQ
+      - 7 # DCHG
+      - 8 # DDSG
+    description: |
+      Pin used for shunt temperature sensing. The *-pin-config property of that pin has to be
+      configured accordingly.
+
+      See include/zephyr/dt-bindings/bms_ic/bq769x2.h for allowed values.
+
   auto-pdsg:
     type: boolean
     description: |

--- a/include/drivers/bms_ic.h
+++ b/include/drivers/bms_ic.h
@@ -171,6 +171,10 @@ struct bms_ic_data
     /** MOSFET temperature (°C) */
     float mosfet_temp;
 #endif
+#ifdef CONFIG_BMS_IC_CURRENT_MONITORING
+    /** Shunt temperature (°C) */
+    float shunt_temp;
+#endif
 
     /** Actual number of cells connected (may be less than CONFIG_BMS_IC_MAX_CELLS) */
     uint8_t connected_cells;

--- a/tests/bms_ic/bq769x2/boards/native_sim.overlay
+++ b/tests/bms_ic/bq769x2/boards/native_sim.overlay
@@ -56,9 +56,11 @@
 		used-cell-channels = <0xFFFF>;
 		/* all NTCs configured with 18k pull-up */
 		ts1-pin-config = <0x07>;
+		dfetoff-pin-config = <0x07>;
 		dchg-pin-config = <0x07>;
 		cell-temp-pins = <BQ769X2_PIN_TS1>;
 		fet-temp-pin = <BQ769X2_PIN_DCHG>;
+		shunt-temp-pin = <BQ769X2_PIN_DFETOFF>;
 		board-max-current = <200>;
 		shunt-resistor-uohm = <1500>;
 		status = "okay";

--- a/tests/bms_ic/bq769x2/src/functions.c
+++ b/tests/bms_ic/bq769x2/src/functions.c
@@ -505,6 +505,18 @@ ZTEST(bq769x2_functions, test_apply_temp_limits)
                   bq769x2_emul_get_data_mem(bms_ic_emul, 0x9262));
 }
 
+ZTEST(bq769x2_functions, test_read_shunt_temp)
+{
+    /* 25°C = 298.15 K = 2981 in 0.1K units */
+    int16_t raw = 2981;
+    bq769x2_emul_set_direct_mem(bms_ic_emul, 0x6C, raw & 0xFF);
+    bq769x2_emul_set_direct_mem(bms_ic_emul, 0x6D, (raw >> 8) & 0xFF);
+
+    int err = bms_ic_read_data(bms.ic_dev, BMS_IC_DATA_TEMPERATURES);
+    zassert_equal(0, err);
+    zassert_within(25.0F, bms.ic_data.shunt_temp, 0.1F);
+}
+
 static void *bq769x2_setup(void)
 {
     common_setup_bms_defaults(&bms);


### PR DESCRIPTION
The BMS-C1 v0.4 has an NTC thermistor connected to the `DFETOFF` pin of the BQ76952 to measure shunt temperature. This adds a new devicetree property `shunt-temp-pin`, following the same pattern as the existing `fet-temp-pin` for MOSFET temperature sensing. The `DFETOFF` pin is configured as 18k NTC input and the temperature is exposed as `rShuntTemp_degC` via ThingSet. Only compiled when `CONFIG_BMS_IC_CURRENT_MONITORING` is enabled.