### PR TITLE
feat(bq769x2): make PDSG configurable and enable on bms_c1

### DIFF
--- a/boards/libresolar/bms_c1/bms_c1.dts
+++ b/boards/libresolar/bms_c1/bms_c1.dts
@@ -99,6 +99,7 @@
 		shunt-temp-pin = <BQ769X2_PIN_DFETOFF>;
 		board-max-current = <100>;
 		shunt-resistor-uohm = <300>;
+		auto-pdsg;
 		status = "okay";
 	};
 };

--- a/drivers/bms_ic/bq769x2/bq769x2.c
+++ b/drivers/bms_ic/bq769x2/bq769x2.c
@@ -540,10 +540,22 @@ static int bq769x2_init_config(const struct device *dev)
         err |= bq769x2_datamem_write_u1(dev, BQ769X2_SET_FET_OPTIONS, 0x1D);
 
         /*
-         * Disable pre-discharge timeout (DSG FETs are only turned on based on bus voltage).
-         * PDSG voltage settings in BQ769X2_SET_FET_PDSG_STOP_DV are kept at default 500 mV.
+         * PDSG timeout in 10 ms units (TRM SLUUBY2B §13.3.6.5, max 2550 ms). A value
+         * of 0 disables the timeout (voltage-only exit) — unsafe on boards with
+         * current-limited precharge resistors under short-circuit load.
          */
-        err |= bq769x2_datamem_write_u1(dev, BQ769X2_SET_FET_PDSG_TIMEOUT, 0);
+        uint16_t timeout_10ms = config->pdsg_timeout_ms / 10;
+        if (timeout_10ms > UINT8_MAX) {
+            timeout_10ms = UINT8_MAX;
+        }
+        err |= bq769x2_datamem_write_u1(dev, BQ769X2_SET_FET_PDSG_TIMEOUT, (uint8_t)timeout_10ms);
+
+        /* PDSG stop voltage delta in 10 mV units (TRM §13.3.6.6, max 2550 mV). */
+        uint16_t stop_dv_10mv = config->pdsg_stop_delta_mv / 10;
+        if (stop_dv_10mv > UINT8_MAX) {
+            stop_dv_10mv = UINT8_MAX;
+        }
+        err |= bq769x2_datamem_write_u1(dev, BQ769X2_SET_FET_PDSG_STOP_DV, (uint8_t)stop_dv_10mv);
     }
     else {
         /* Disable automatic pre-discharge before switching on DSG FETs */
@@ -1016,6 +1028,8 @@ static const struct bms_ic_driver_api bq769x2_driver_api = {
         .shunt_temp_pin = DT_INST_PROP_OR(index, shunt_temp_pin, UINT8_MAX),               \
         .crc_enabled = DT_INST_PROP(index, crc_enabled),                                   \
         .auto_pdsg = DT_INST_PROP(index, auto_pdsg),                                       \
+        .pdsg_timeout_ms = DT_INST_PROP(index, pdsg_timeout_ms),                           \
+        .pdsg_stop_delta_mv = DT_INST_PROP(index, pdsg_stop_delta_mv),                     \
         .reg0_config = DT_INST_PROP(index, reg0_config),                                   \
         .reg12_config = DT_INST_PROP(index, reg12_config),                                 \
         .max_balanced_cells = DT_INST_PROP(index, max_balanced_cells),                     \

--- a/drivers/bms_ic/bq769x2/bq769x2_priv.h
+++ b/drivers/bms_ic/bq769x2/bq769x2_priv.h
@@ -60,6 +60,8 @@ struct bms_ic_bq769x2_config
     uint8_t shunt_temp_pin;
     bool crc_enabled;
     bool auto_pdsg;
+    uint16_t pdsg_timeout_ms;
+    uint16_t pdsg_stop_delta_mv;
     uint8_t reg0_config;
     uint8_t reg12_config;
     uint8_t max_balanced_cells;

--- a/dts/bindings/bms_ic/ti,bq769x2-common.yaml
+++ b/dts/bindings/bms_ic/ti,bq769x2-common.yaml
@@ -123,6 +123,37 @@ properties:
     description: |
       Enable automatic pre-discharge (bus precharge) before switching on DSG FETs.
 
+  pdsg-timeout-ms:
+    type: int
+    default: 2000
+    description: |
+      Maximum duration of the PDSG (bus precharge) phase in milliseconds. The BQ76952
+      transitions from PDSG to DSG when the bus voltage reaches the pack voltage minus
+      PDSG Stop Delta, OR when this timeout expires, whichever happens first.
+
+      Setting this to 0 disables the timeout (voltage-based exit only), which is NOT
+      recommended for boards with current-limited precharge resistors: a short-circuit
+      load prevents the voltage condition from ever being met, keeping PDSG active
+      indefinitely and overloading the precharge resistor.
+
+      Default 2000 ms covers a typical DC-link capacitance up to ~10 mF with safety
+      margin. Set to 0 only if the precharge resistor can survive indefinite loading.
+
+      Granularity is 10 ms (values are rounded down to nearest 10 ms). Maximum
+      effective value is 2550 ms (BQ76952 TRM SLUUBY2B §13.3.6.5).
+
+      Only relevant when auto-pdsg is set.
+
+  pdsg-stop-delta-mv:
+    type: int
+    default: 500
+    description: |
+      Voltage delta in millivolts for the PDSG exit condition. PDSG ends when the LD pin
+      voltage is within this delta of the top-of-stack voltage. Default 500 mV matches
+      the BQ76952 factory default. Granularity is 10 mV, max 2550 mV.
+
+      Only relevant when auto-pdsg is set.
+
   reg0-config:
     type: int
     default: 0


### PR DESCRIPTION
Follow-up to #95.

When `auto-pdsg` is set, the driver currently writes `PDSG_TIMEOUT = 0` (no timeout) and relies entirely on the voltage-based exit condition (`LD` within `PDSG_STOP_DV` of top-of-stack). That is unsafe on boards with current-limited precharge resistors: under a short-circuit load on the DC link the voltage condition is never met, so PDSG stays active indefinitely and the precharge resistor cooks. On the e.BMS C1, `R63` is rated for 0.5 A continuous but would carry ~1.5 A / 90 W in that scenario.

This patch adds two device tree properties so boards can pick safe values:

- `pdsg-timeout-ms` (default 2000 ms) caps the PDSG phase. 2 s covers a typical DC-link capacitance up to about 10 mF with margin, and on a stuck precharge it limits the resistor's exposure.
- `pdsg-stop-delta-mv` (default 500 mV) exposes the voltage exit threshold, which already defaulted to 500 mV in the BQ but was hidden behind a hardcoded register write.

Both are written to `BQ769X2_SET_FET_PDSG_TIMEOUT` / `BQ769X2_SET_FET_PDSG_STOP_DV` only when `auto-pdsg` is set, and only inside the existing `auto-pdsg` branch in `bq769x2_init_config`. Granularity matches the BQ register (10 ms / 10 mV, rounded down, capped at 2550). See TRM SLUUBY2B §13.3.6.5 and §13.3.6.6.

The second commit re-enables `auto-pdsg` on the in-tree `bms_c1` board. Before f0ff664 ("Massive Update", 2023-10-20) PDSG was hardcoded on for every board in `bms_init_hardware()`. That commit moved the toggle into a DTS property but did not set it on any board, so PDSG has been silently off on `bms_c1` since then even though `R63` (40 Ω) is wired up as the precharge resistor on the PDSG path. Setting `auto-pdsg` here restores the pre-regression behaviour, and the new 2 s default timeout makes it safer than what was there before (which had no timeout).

Behaviour change: any board that already set `auto-pdsg` without specifying `pdsg-timeout-ms` (none in-tree today) goes from "no timeout" to 2 s. That is a safety improvement, but boards with DC-link capacitance above ~10 mF should re-validate or set `pdsg-timeout-ms` explicitly.

Depends on #95 for the `auto-pdsg` runtime path to actually work; without it `PDSG_OFF` is asserted on every `set_switches` call regardless of the DTS setting.