### PR TITLE
Upgrade to Zephyr v4.4

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -14,13 +14,13 @@ jobs:
         working-directory: firmware
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: firmware
           fetch-depth: 0 # necessary to get tags
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/boards/libresolar/bms_15s80_sc/board.yml
+++ b/boards/libresolar/bms_15s80_sc/board.yml
@@ -1,5 +1,6 @@
 board:
   name: bms_15s80_sc
+  full_name: Libre Solar BMS 15S80 SC
   vendor: libresolar
   socs:
     - name: stm32f072xb

--- a/boards/libresolar/bms_16s100_sc/board.yml
+++ b/boards/libresolar/bms_16s100_sc/board.yml
@@ -1,5 +1,6 @@
 board:
   name: bms_16s100_sc
+  full_name: Libre Solar BMS 16S100 SC
   vendor: libresolar
   socs:
     - name: stm32g0b1xx

--- a/boards/libresolar/bms_5s50_sc/board.yml
+++ b/boards/libresolar/bms_5s50_sc/board.yml
@@ -1,5 +1,6 @@
 board:
   name: bms_5s50_sc
+  full_name: Libre Solar BMS 5S50 SC
   vendor: libresolar
   socs:
     - name: stm32f072xb

--- a/boards/libresolar/bms_8s50_ic/board.yml
+++ b/boards/libresolar/bms_8s50_ic/board.yml
@@ -1,5 +1,6 @@
 board:
   name: bms_8s50_ic
+  full_name: Libre Solar BMS 8S50 IC
   vendor: libresolar
   socs:
     - name: stm32l452xx
@@ -7,5 +8,5 @@ board:
     format: major.minor.patch
     default: "0.2.0"
     revisions:
-    - name: "0.2.0"
-    - name: "0.1.0"
+      - name: "0.2.0"
+      - name: "0.1.0"

--- a/boards/libresolar/bms_c1/board.yml
+++ b/boards/libresolar/bms_c1/board.yml
@@ -1,5 +1,6 @@
 board:
   name: bms_c1
+  full_name: Libre Solar BMS C1
   vendor: libresolar
   socs:
     - name: esp32c3
@@ -7,5 +8,5 @@ board:
     format: major.minor.patch
     default: "0.4.0"
     revisions:
-    - name: "0.4.0"
-    - name: "0.3.0"
+      - name: "0.4.0"
+      - name: "0.3.0"

--- a/boards/shields/uext_oled/uext_oled.overlay
+++ b/boards/shields/uext_oled/uext_oled.overlay
@@ -14,7 +14,7 @@
 	status = "okay";
 
 	ssd1306_128x64: ssd1306@3c {
-		compatible = "solomon,ssd1306fb";
+		compatible = "solomon,ssd1306";
 		reg = <0x3c>;
 		width = <128>;
 		height = <64>;

--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject
-      revision: v4.3-branch
+      revision: v4.4-branch
       import:
         name-allowlist:
           - cmsis_6
@@ -22,11 +22,12 @@ manifest:
           - hal_stm32
           - mbedtls
           - mcuboot
+          - tf-psa-crypto
           - tinycrypt
           - zcbor
     - name: thingset-zephyr-sdk
       remote: thingset
-      revision: 9784e05914a7b3270802c84c10f52a640c823348
+      revision: 8b32f7db1898dc51daa1834b3f8058de6a67166f
       path: thingset-zephyr-sdk
       import:
         name-allowlist:


### PR DESCRIPTION
Also pulling in the latest version of ThingSet, which implements the API changes introduced in Zephyr v4.4.