### PR TITLE
bq769x2: Gate shunt temperature sensing behind BMS_IC_SHUNT_TEMP

### DIFF
--- a/app/src/data_objects.c
+++ b/app/src/data_objects.c
@@ -224,7 +224,7 @@ THINGSET_ADD_ITEM_FLOAT(APP_ID_MEAS, APP_ID_MEAS_MOSFET_TEMP, "rMOSFETTemp_degC"
                         &bms.ic_data.mosfet_temp, 1, THINGSET_ANY_R, TS_SUBSET_LIVE);
 #endif
 
-#ifdef CONFIG_BMS_IC_CURRENT_MONITORING
+#ifdef CONFIG_BMS_IC_SHUNT_TEMP
 THINGSET_ADD_ITEM_FLOAT(APP_ID_MEAS, APP_ID_MEAS_SHUNT_TEMP, "rShuntTemp_degC",
                         &bms.ic_data.shunt_temp, 1, THINGSET_ANY_R, TS_SUBSET_LIVE);
 #endif

--- a/boards/libresolar/bms_c1/bms_c1.dts
+++ b/boards/libresolar/bms_c1/bms_c1.dts
@@ -92,11 +92,9 @@
 		/* all NTCs configured with 18k pull-up */
 		ts1-pin-config = <0x07>;
 		ts3-pin-config = <0x07>;
-		dfetoff-pin-config = <0x07>;
 		dchg-pin-config = <0x0F>;
 		cell-temp-pins = <BQ769X2_PIN_TS1 BQ769X2_PIN_TS3>;
 		fet-temp-pin = <BQ769X2_PIN_DCHG>;
-		shunt-temp-pin = <BQ769X2_PIN_DFETOFF>;
 		board-max-current = <100>;
 		shunt-resistor-uohm = <300>;
 		auto-pdsg;

--- a/boards/libresolar/bms_c1/bms_c1_0_4_0.overlay
+++ b/boards/libresolar/bms_c1/bms_c1_0_4_0.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <dt-bindings/bms_ic/bq769x2.h>
+
 / {
 	pcb {
 		version-str = "v0.4";
@@ -29,4 +31,10 @@
 			output-high;
 		};
 	};
+};
+
+&bq76952 {
+	/* DFETOFF wired to shunt NTC on v0.4 only */
+	dfetoff-pin-config = <0x07>;
+	shunt-temp-pin = <BQ769X2_PIN_DFETOFF>;
 };

--- a/drivers/bms_ic/Kconfig
+++ b/drivers/bms_ic/Kconfig
@@ -18,6 +18,12 @@ config BMS_IC_HAS_CURRENT_MONITORING
 	help
 	  Select to indicate that the IC supports current monitoring.
 
+config BMS_IC_HAS_SHUNT_TEMP
+	bool
+	help
+	  Select to indicate that the IC supports shunt temperature sensing
+	  via a configurable pin.
+
 module = BMS_IC
 module-str = bms_ic
 source "subsys/logging/Kconfig.template.log_config"
@@ -36,6 +42,7 @@ config BMS_IC_BQ769X2
 	bool "Texas Instruments bq769x2 series"
 	depends on DT_HAS_TI_BQ769X2_I2C_ENABLED || DT_HAS_TI_BQ769X2_SPI_ENABLED
 	select BMS_IC_HAS_CURRENT_MONITORING
+	select BMS_IC_HAS_SHUNT_TEMP
 	select BMS_IC_HAS_SWITCHES
 	select CRC
 	default y
@@ -72,6 +79,19 @@ config BMS_IC_CURRENT_MONITORING
 	help
 	  Use the current monitoring features if available in the IC. Can be disabled to reduce
 	  code size.
+
+config BMS_IC_SHUNT_TEMP
+	bool "Read shunt temperature via BMS IC"
+	depends on BMS_IC_HAS_SHUNT_TEMP
+	depends on $(dt_node_has_prop,bms-ic,shunt-temp-pin)
+	default y
+	help
+	  Enable reading of the shunt temperature through the BMS IC's configurable
+	  thermistor pin. Only visible when the bms-ic devicetree node has the
+	  shunt-temp-pin property set (the *-pin-config of that pin must also be
+	  configured as NTC input). Hardware support is board-revision-specific,
+	  so this is automatically hidden on boards/revisions that do not wire a
+	  shunt NTC.
 
 config BMS_IC_SWITCHES
 	bool "Control switches via BMS IC"

--- a/drivers/bms_ic/bq769x2/bq769x2.c
+++ b/drivers/bms_ic/bq769x2/bq769x2.c
@@ -739,7 +739,7 @@ static int bq769x2_read_temperatures(const struct device *dev, struct bms_ic_dat
     }
 #endif
 
-#ifdef CONFIG_BMS_IC_CURRENT_MONITORING
+#ifdef CONFIG_BMS_IC_SHUNT_TEMP
     /* Read shunt temperature if a pin was defined in Devicetree */
     if (config->shunt_temp_pin < ARRAY_SIZE(config->pin_config)) {
         err |= bq769x2_direct_read_i2(dev, BQ769X2_CMD_TEMP_CFETOFF + config->shunt_temp_pin * 2U,

--- a/include/drivers/bms_ic.h
+++ b/include/drivers/bms_ic.h
@@ -171,7 +171,7 @@ struct bms_ic_data
     /** MOSFET temperature (°C) */
     float mosfet_temp;
 #endif
-#ifdef CONFIG_BMS_IC_CURRENT_MONITORING
+#ifdef CONFIG_BMS_IC_SHUNT_TEMP
     /** Shunt temperature (°C) */
     float shunt_temp;
 #endif


### PR DESCRIPTION
The https://github.com/LibreSolar/bms-firmware/commit/690a8c37f971079f60156e836cba207e082929cd shunt-temp-sensing commit unconditionally configured DFETOFF as NTC input and added the `shunt-temp-pin` property on the common `bms_c1.dts`. The BMS C1 v0.3 hardware does not wire a shunt NTC to DFETOFF, so this misconfigured the pin on v0.3 builds and exposed a non-functional `rShuntTemp_degC` via ThingSet. Issue raised in https://github.com/LibreSolar/bms-c1/issues/45#issuecomment-4457486762.

This PR makes the feature opt-in per board revision:

- Move `dfetoff-pin-config` and `shunt-temp-pin` from `bms_c1.dts` into `bms_c1_0_4_0.overlay` (the only revision wired for it).
- Introduce `BMS_IC_HAS_SHUNT_TEMP` capability (selected by the bq769x2 driver) + user-facing `BMS_IC_SHUNT_TEMP` option, which `depends on $(dt_node_has_prop,bms-ic,shunt-temp-pin)` so it is automatically hidden on board revisions / boards that do not wire a shunt NTC, and `default y` where the property is present.
- Gate the `shunt_temp` field in `struct bms_ic_data`, the bq769x2 read path, and the ThingSet `rShuntTemp_degC` item on `CONFIG_BMS_IC_SHUNT_TEMP`.

No `.conf` file is needed for v0.4, the DT property itself is the single source of truth.